### PR TITLE
Fix events classifications for BIDS client

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,8 +28,7 @@ RUN apt-get update && \
 
 ENV SRCDIR /src
 RUN mkdir -p ${SRCDIR}
-ADD https://github.com/INCF/bids-validator/archive/0.24.0.tar.gz ${SRCDIR}
-RUN tar xzf ${SRCDIR}/0.24.0.tar.gz -C ${SRCDIR}
+RUN wget -O - https://github.com/INCF/bids-validator/archive/0.24.0.tar.gz | tar xz -C ${SRCDIR}
 RUN npm install -g /src/bids-validator-0.24.0/
 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,7 @@ RUN apt-get update && \
 ENV SRCDIR /src
 RUN mkdir -p ${SRCDIR}
 ADD https://github.com/INCF/bids-validator/archive/0.24.0.tar.gz ${SRCDIR}
+RUN tar xzf ${SRCDIR}/0.24.0.tar.gz -C ${SRCDIR}
 RUN npm install -g /src/bids-validator-0.24.0/
 
 

--- a/supporting_files/classifications.py
+++ b/supporting_files/classifications.py
@@ -19,11 +19,13 @@ classifications = {
         },
         'func': {
             'bold': 'functional',
+            'events': 'functional',
             'sbref': 'functional',
             'stim': 'stimulus',    # stimulus
             'physio': 'physio'     # physio
         },
         'beh' : {
+            'events': 'behavioral',
             'stim': 'stimulus',    # stimulus
             'physio': 'physio'     # physio
         },

--- a/supporting_files/templates.py
+++ b/supporting_files/templates.py
@@ -121,9 +121,10 @@ func_file_template = {
 # Matches to functional
 task_events_file_template = {
     "container_type": "file",
-    "description": "BIDS template for task files",
+    "description": "BIDS template for task events files",
     "where": {
-        "type": [u"tabular data", u"Tabular Data"]
+        "type": [u"tabular data", u"Tabular Data"],
+        "measurements": [u"functional"]
     },
     "properties": {
         "Filename": {"type": "string", "label": "Filename", "default": "",
@@ -140,60 +141,22 @@ task_events_file_template = {
     "required": ["Filename", "Folder", "Path", "Task"]
 }
 
-# Matches to functional
-physio_events_file_template = {
-    "container_type": "file",
-    "description": "BIDS template for task files",
-    "where": {
-        "measurements": [u"physio"] # TODO: determine this... what is the measurement name of physio data?
-    },
-    "properties": {
-        "Filename": {"type": "string", "label": "Filename", "default": "",
-            "auto_update": 'sub-<subject.code>[_ses-<session.label>]_task-{file.info.BIDS.Task}[_acq-{file.info.BIDS.Acq}][_rec-{file.info.BIDS.Rec}][_run-{file.info.BIDS.Run}][_echo-{file.info.BIDS.Echo}][_recording-{file.info.BIDS.Recording}]_{file.info.BIDS.Modality}{ext}'},
-        "Folder": {"type": "string", "label": "Folder", "default": "func"},
-        "Path": {"type": "string", "label": "Path", "default": "",
-            "auto_update": 'sub-<subject.code>[/ses-<session.label>]/{file.info.BIDS.Folder}'},
-        "Task": {"type": "string", "label": "Task Label", "default": ""},
-        "Acq": {"type": "string", "label": "Acq Label", "default": ""},
-        "Rec": {"type": "string", "label": "Rec Label", "default": ""},
-        "Run": {"type": "string", "label": "Run Index", "default": ""},
-        "Echo": {"type": "string", "label": "Echo Index", "default": ""},
-        "Recording": {"type": "string", "label": "Recording Label", "default": ""},
-        "Modality": {"type": "string", "label": "Modality Label", "default": "physio",
-            "enum": [
-                "physio",
-                "stim"
-            ]
-        }
-
-    },
-    "required": ["Filename", "Folder", "Path", "Task", "Modality"]
-}
-
 beh_events_file_template = {
     "container_type": "file",
-    "description": "BIDS template for task files",
+    "description": "BIDS template for behavioral events files",
     "where": {
+        "type": [u"tabular data", u"Tabular Data"],
         "measurements": ["behavioral"] # TODO: determine this... what is the measurement name of behavioral experiments?
     },
     "properties": {
         "Filename": {"type": "string", "label": "Filename", "default": "",
-            "auto_update": 'sub-<subject.code>[_ses-<session.label>]_task-{file.info.BIDS.Task}_{file.info.BIDS.Modality}{ext}'},
+            "auto_update": 'sub-<subject.code>[_ses-<session.label>]_task-{file.info.BIDS.Task}_events.tsv'},
         "Folder": {"type": "string", "label": "Folder", "default": "beh"},
         "Path": {"type": "string", "label": "Path", "default": "",
             "auto_update": 'sub-<subject.code>[/ses-<session.label>]/{file.info.BIDS.Folder}'},
-        "Task": {"type": "string", "label": "Task Label", "default": ""},
-        "Modality": {"type": "string", "label": "Modality Label", "default": "beh",
-            "enum": [
-                "beh",
-                "events",
-                "physio",
-                "stim"
-            ]
-        }
-
+        "Task": {"type": "string", "label": "Task Label", "default": ""}
     },
-    "required": ["Filename", "Folder", "Path", "Task", "Modality"]
+    "required": ["Filename", "Folder", "Path", "Task"]
 }
 
 
@@ -293,7 +256,7 @@ namespace = {
         anat_file_template,
         func_file_template,
         task_events_file_template,
-        physio_events_file_template,
+        beh_events_file_template,
         diffusion_file_template,
         fieldmap_file_template,
         dicom_file_template,

--- a/supporting_files/templates.py
+++ b/supporting_files/templates.py
@@ -123,8 +123,7 @@ task_events_file_template = {
     "container_type": "file",
     "description": "BIDS template for task files",
     "where": {
-        "type": [u"tabular data", u"Tabular Data"],
-        "measurements": [u"functional"]
+        "type": [u"tabular data", u"Tabular Data"]
     },
     "properties": {
         "Filename": {"type": "string", "label": "Filename", "default": "",

--- a/upload_bids.py
+++ b/upload_bids.py
@@ -220,11 +220,20 @@ def upload_acquisition_file(fw, context, full_fname):
     ### Classify acquisition
     # Get classification based on filename
     classification = classify_acquisition(full_fname)
-    # Assign classification
+
+    update = {}
+    
     if classification:
+        update['measurements'] = [classification]
+
+    # Workaround for tsv tabular data (remove with mongo-filetypes branch)
+    if context['file']['name'].endswith('.tsv') or context['file']['name'].endswith('.tsv.gz'):
+        update['type'] = 'tabular data'
+
+    # Assign classification
+    if update:
         fw.modify_acquisition_file(context['acquisition']['_id'],
-              context['file']['name'],
-           {'measurements': [classification]})
+              context['file']['name'], update)
 
     # Get acquisition
     acq = fw.get_acquisition(context['acquisition']['_id'])


### PR DESCRIPTION
@gsfr @ryansanford These are my proposed changes based on my understanding of the BIDS spec. Effectively, the changes ensure:
1. TSV files get assigned the 'tabular data' file type (pre `mongo-filetypes` fix)
2. Events files get classified based on folder name
3. Events match a template

Tested with BIDS-examples data.

