### PR TITLE
Check that templateDef is set

### DIFF
--- a/supporting_files/bidsify_flywheel.py
+++ b/supporting_files/bidsify_flywheel.py
@@ -181,8 +181,9 @@ def process_matching_templates(context, template=templates.DEFAULT_TEMPLATE):
         # Do auto_updates
         if not templateDef:
             templateDef = template.definitions.get(container['info'][template.namespace]['template'])
-        data = update_properties(templateDef["properties"], context, {})
-        container['info'][namespace].update(data)
+        if templateDef:
+            data = update_properties(templateDef["properties"], context, {})
+            container['info'][namespace].update(data)
 
     return container
 

--- a/tests/test_curate_bids.py
+++ b/tests/test_curate_bids.py
@@ -113,6 +113,18 @@ class BidsCurateTestCases(unittest.TestCase):
         self.assertEqual(meta_info['info']['BIDS']['error_message'],
                 'Missing required property: Modality. ')
 
+    def test_validate_meta_info_invalid4(self):
+        """ """
+        # Define meta information - invalid/unknown/NO_MATCH template
+        meta_info = {'info': {'BIDS': {'template': 'NO_MATCH', 'Modality': 'bold'}}}
+        # Call function
+        curate_bids.validate_meta_info(meta_info, BIDS_TEMPLATE)
+        # Assert 'BIDS.valid' == False
+        self.assertFalse(meta_info['info']['BIDS']['valid'])
+        # Assert error message is correct
+        self.assertEqual(meta_info['info']['BIDS']['error_message'],
+                'Unknown template: NO_MATCH. ')
+
     def test_validate_meta_info_invalid_characters1(self):
         """ """
         # Define meta information - invalid characters in multiple keys


### PR DESCRIPTION
Simple check to make sure that the templateDef is not None. When templateDef is None, meaning the template field in the BIDS object didn't match any template, the validate_meta_info function will set the error_message and the valid field.