### PR TITLE
Don't set info if file doesn't match a template

### DIFF
--- a/curate_bids.py
+++ b/curate_bids.py
@@ -251,7 +251,7 @@ if __name__ == '__main__':
             required=True, help='API key')
     parser.add_argument('-p', dest='project_label', action='store',
             required=False, default=None, help='Project Label on Flywheel instance')
-    parser.add_argument('--reset', dest='reset', action='store_true', 
+    parser.add_argument('--reset', dest='reset', action='store_true',
             default=False, help='Reset BIDS data before running')
     parser.add_argument('--template-file', dest='template_file', action='store',
             default=None, help='Template file to use')

--- a/supporting_files/bidsify_flywheel.py
+++ b/supporting_files/bidsify_flywheel.py
@@ -147,7 +147,7 @@ def process_matching_templates(context, template=templates.DEFAULT_TEMPLATE):
     container_type = context['container_type']
     container = context[container_type]
 
-    initial = (('info' not in container) or (namespace not in container['info']) 
+    initial = (('info' not in container) or (namespace not in container['info'])
             or ('template' not in container['info'][namespace]))
 
     templateDef = None
@@ -175,7 +175,6 @@ def process_matching_templates(context, template=templates.DEFAULT_TEMPLATE):
                 break
         if not match:
             print 'no template matched for {} in {} {}'.format(container['name'], context['parent_container_type'], context[context['parent_container_type']]['_id'])
-            container['info'] = {namespace: {'template': 'NO_MATCH'}}
 
     if not initial:
         # Do auto_updates

--- a/upload_bids.py
+++ b/upload_bids.py
@@ -557,10 +557,12 @@ def upload_bids_dir(fw, bids_hierarchy, group_id, rootdir, hierarchy_type):
                         context['ext'] = utils.get_extension(fname)
                         # Identify the templates for the file and return file object
                         context['file'] = bidsify_flywheel.process_matching_templates(context, template)
-                        # Update the meta info files w/ BIDS info from the filename and foldername...
-                        meta_info = fill_in_properties(context, full_path)
-                        # Upload the meta info onto the project file
-                        fw.set_acquisition_file_info(context['acquisition']['_id'], fname, meta_info)
+                        # Check that the file matched a template
+                        if context['file'].get('info'):
+                            # Update the meta info files w/ BIDS info from the filename and foldername...
+                            meta_info = fill_in_properties(context, full_path)
+                            # Upload the meta info onto the project file
+                            fw.set_acquisition_file_info(context['acquisition']['_id'], fname, meta_info)
 
                         # Check if any acquisition files are of interest (to be parsed later)
                         #   interested in JSON files


### PR DESCRIPTION
- Info isn't set by the uploader if a file isn't matched to a template, the curator will set info.BIDS to 'NA' which the exporter knows to ignore when downloading. 
  - I left in the print statements that log when a file doesn't match a template
- TaskName doesn't need to be alphanumeric according to the bids spec and until we get the full json schema validation, this seemed to be way to make sure files weren't being set to invalid when they were valid.