### PR TITLE
Template Rules format strings for properties on initialization

### DIFF
--- a/supporting_files/templates.py
+++ b/supporting_files/templates.py
@@ -288,7 +288,7 @@ def formatValue(params, value):
     """
     for param in params:
         if "$replace" in param:
-            value = value.replace(param["$replace"].get('$pattern'), param["$replace"].get('$replacement'))
+            value = re.sub(param["$replace"].get('$pattern'), param["$replace"].get('$replacement'), value)
     return value
 
 def loadTemplates(templates_dir=None):

--- a/supporting_files/templates.py
+++ b/supporting_files/templates.py
@@ -28,7 +28,7 @@ class Template:
             self.description = data.get('description', '')
             self.definitions = data.get('definitions', {})
             self.rules = data.get('rules', [])
-            
+
             self.extends = data.get('extends')
             self.exclude_rules = data.get('exclude_rules', [])
         else:
@@ -79,7 +79,7 @@ class Template:
             rule = self.rules[i]
             if not isinstance(rule, Rule):
                 self.rules[i] = Rule(rule)
-            
+
     def validate(self, templateDef, info):
         """
         Validate info against a template definition schema.
@@ -106,7 +106,7 @@ class Template:
             parent (object): The parent object
             key: The key to the parent object
         """
-        if isinstance(obj, dict): 
+        if isinstance(obj, dict):
             if parent and '$ref' in obj:
                 ref, result = resolver.resolve(obj['$ref'])
                 parent[key] = result
@@ -144,7 +144,7 @@ class Rule:
     def test(self, context):
         """
         Test if the given context matches this rule.
-        
+
         Args:
             context (dict): The context, which includes the hierarchy and current container
 
@@ -207,6 +207,9 @@ class Rule:
                             elif '$take' in valueSpec and valueSpec['$take']:
                                 resolvedValue = value
 
+                            if '$format' in valueSpec and resolvedValue:
+                                resolvedValue = formatValue(valueSpec['$format'], resolvedValue)
+
                             if resolvedValue:
                                 break
             else:
@@ -249,7 +252,7 @@ def processValueMatch(value, match):
                     if item in match['$in']:
                         return True
                 return False
-            
+
             return value in match['$in']
 
         elif '$not' in match:
@@ -265,8 +268,8 @@ def processValueMatch(value, match):
                         return True
 
                 return False
-            
-            return regex.search(value) is not None 
+
+            return regex.search(value) is not None
 
     else:
         # Direct match
@@ -278,10 +281,20 @@ def processValueMatch(value, match):
 
         return value == match
 
+def formatValue(params, value):
+    """
+    Formats a string value based on given parameters i.e. {"$replace": {"$pattern": "ab", "$replacement": "c"}}
+    will return "dcf" from "dabf"
+    """
+    for param in params:
+        if "$replace" in param:
+            value = value.replace(param["$replace"].get('$pattern'), param["$replace"].get('$replacement'))
+    return value
+
 def loadTemplates(templates_dir=None):
     """
     Load all templates in the given (or default) directory
-    
+
     Args:
         templates_dir (string): The optional directory to load templates from.
     """
@@ -303,7 +316,7 @@ def loadTemplates(templates_dir=None):
 def loadTemplate(path, templates=None):
     """
     Load the template at path
-    
+
     Args:
         path (str): The path to the template to load
         templates (dict): The mapping of template names to template defintions.

--- a/supporting_files/utils.py
+++ b/supporting_files/utils.py
@@ -71,6 +71,8 @@ def dict_lookup(obj, value):
     for part in parts:
         if isinstance(curr, dict) and part in curr:
             curr = curr[part]
+        elif isinstance(curr, list) and int(part) < len(curr):
+            curr = curr[int(part)]
         else:
             curr = None
             break

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -79,4 +79,24 @@ class RuleTestCases(unittest.TestCase):
         rule.initializeProperties(info, context)
         self.assertEqual( info, { 'Property': 'no_match' } )
 
+    def test_rule_initialize_format(self):
+        rule = templates.Rule({
+            'template': 'test',
+            'where': { 'x': True },
+            'initialize': {
+                'Property': {
+                    'value': {
+                        '$take': True,
+                        '$format': [
+                            {'$replace': {'$pattern': 'OLD', '$replacement': 'NEW'}}
+                        ]
+                    }
+                }
+            }
+        })
+        context = { 'value': 'The_OLD_String' }
+        info = { }
+        rule.initializeProperties(info, context)
+        self.assertEqual( info, { 'Property': 'The_NEW_String'})
+
 

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -88,15 +88,18 @@ class RuleTestCases(unittest.TestCase):
                     'value': {
                         '$take': True,
                         '$format': [
-                            {'$replace': {'$pattern': 'OLD', '$replacement': 'NEW'}}
+                            # Use regex to find patterns
+                            {'$replace': {'$pattern': '[A-Z]+', '$replacement': 'NEW'}},
+                            # Chain formatting operations
+                            {'$replace': {'$pattern': 'EW', '$replacement': 'ew'}}
                         ]
                     }
                 }
             }
         })
-        context = { 'value': 'The_OLD_String' }
+        context = { 'value': 'the_OLD_string' }
         info = { }
         rule.initializeProperties(info, context)
-        self.assertEqual( info, { 'Property': 'The_NEW_String'})
+        self.assertEqual( info, { 'Property': 'the_New_string'})
 
 


### PR DESCRIPTION
### $format
Example: 
A rule with
```
"initialize": {
    'Property': {
        'value': {
             '$take': True,
             '$format': [
                 {'$replace': {'$pattern': 'OLD', '$replacement': 'NEW'}}
             ]
        }
    }
}
```
will initialize `{'value': "The_OLD_String")` as `{"Property": "The_NEW_String"}`
##### Notes
- Only implemented `"$replace"` so far
- `"$format"` is an ordered list so it can be chained

### Other Changes
- can lookup lists in templates
  - `file.info.ImageType.2` will return index 2 of ImageType