### PR TITLE
Run indexes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ MAINTAINER Flywheel <support@flywheel.io>
 
 # Install jsonschema
 RUN pip install jsonschema==2.6.0
+RUN pip install python-dateutil==2.6.1
 
 # Install BIDS validator from INCF
 #     https://github.com/INCF/bids-validator

--- a/curate_bids.py
+++ b/curate_bids.py
@@ -173,6 +173,9 @@ def curate_bids_tree(fw, project, reset=False, template_file=None, update=True):
             # Returns true if modified
             bidsify_flywheel.ensure_info_exists(context['session'], template)
 
+            # Add run_counter
+            context['run_counters'] = utils.RunCounterMap()
+
         elif ctype == 'file':
             if parent_ctype == 'project' and context['file']['name'] == PROJECT_TEMPLATE_FILE_NAME:
                 # Don't BIDSIFY project template

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 jsonschema==2.6.0
-https://github.com/flywheel-io/sdk/releases/download/0.2.0/flywheel-0.2.0-py2-none-linux_x86_64.whl
+python-dateutil==2.6.1
+https://github.com/flywheel-io/sdk/releases/download/0.3.0/flywheel-0.3.0-py2-none-linux_x86_64.whl
 pytest==3.2.5

--- a/supporting_files/templates.py
+++ b/supporting_files/templates.py
@@ -218,6 +218,8 @@ class Rule:
             if resolvedValue:
                 info[propName] = resolvedValue
 
+        self._handleRunCounters(info, context)
+
     def _handleSwitch(self, switchDef, context):
         value = utils.dict_lookup(context, switchDef['$on'])
         if isinstance(value, list):
@@ -232,6 +234,24 @@ class Rule:
                 return caseDef.get('$value')
 
         return None
+
+    def _handleRunCounters(self, info, context):
+        counter = context.get('run_counters')
+        if not counter:
+            return
+
+        for propName, propDef in self.initialize.items():
+            if isinstance(propDef, dict) and '$run_counter' in propDef:
+                current = info.get(propName)
+                if current == '+' or current == '=':
+                    key = propDef['$run_counter']['key']
+                    key = utils.process_string_template(key, context)
+
+                    counter = counter[key]                            
+                    if current == '+':
+                        info[propName] = counter.next()
+                    else:
+                        info[propName] = counter.current()
 
 
 def processValueMatch(value, match):

--- a/supporting_files/utils.py
+++ b/supporting_files/utils.py
@@ -87,4 +87,89 @@ def normalize_strings(obj):
         return type(obj)(map(normalize_strings, obj))
     return obj
 
+# process_string_template(template, context)
+# finds values in the context object and substitutes them into the string template
+# Use <path> for cases where you want the result converted to lowerCamelCase
+# Use {path} for cases where you want a literal value substitution
+# path uses dot notation to navigate the context for desired values
+# path examples:  <session.label>  returns session.label in lowercamelcase
+#                 {file.info.BIDS.Filename} returns the value of file.info.BIDS.Filename
+#                 {file.info.BIDS.Modality} returns Modality without modification
+# example template string:
+#       'sub-<subject.code>_ses-<session.label>_acq-<acquisition.label>_{file.info.BIDS.Modality}.nii.gz'
+
+def process_string_template(template, context):
+    tokens = re.compile('[^\[][A-Za-z0-9\.><}{-]+|\[[/A-Za-z0-9><}{_\.-]+\]')
+    values = re.compile('[{<][A-Za-z0-9\.-]+[>}]')
+
+    for token in tokens.findall(template):
+        if values.search(token):
+            replace_tokens = values.findall(token)
+            for replace_token in replace_tokens:
+                # Remove the {} or <> surrounding the replace_token
+                path = replace_token[1:-1]
+                # Get keys, if replace token has a . in it
+                keys = path.split(".")
+                result = context
+                for key in keys:
+                    if key in result:
+                        result = result[key]
+                    else:
+                        result = None
+                        break
+                # If value found replace it
+                if result:
+                    # If replace token is <>, need to check if in BIDS
+                    if replace_token[0] == '<':
+                        # Check if result is already in BIDS format...
+                        #   if so, split and grab only the label
+                        if re.match('(sub|ses)-[a-zA-Z0-9]+', result):
+                            label, result = result.split('-')
+                        # If not, take the entire result and remove underscores and dashes
+                        else:
+                            result = ''.join(x for x in result.replace('_', ' ').replace('-', ' ').title() if x.isalnum())
+                            result = result[0].lower() + result[1:]
+
+                    # Replace the token with the result
+                    template = template.replace(replace_token, str(result))
+                # If result not found, but the token is option, remove the token from the template
+                elif token[0] == '[':
+                    template = template.replace(token, '')
+
+                # TODO: Determine approach
+                # Else the value hasn't been found AND field is required, and so let's replace with 'UNKNOWN'
+                #elif token[0] != '[':
+                #    result = 'UNKNOWN'
+                #    template = template.replace(replace_token, result)
+        else:
+            pass
+
+    # Replace any [] from the string
+    processed_template = re.sub('\[|\]', '', template)
+
+    return processed_template
+
+
+class RunCounter:
+    def __init__(self):
+        self.current = 0
+
+    def next(self):
+        self.current = self.current + 1
+        return str(self.current)
+
+    def current(self):
+        return str(self.current)
+
+class RunCounterMap:
+    def __init__(self):
+        self.entries = {}
+
+    def __getitem__(self, key):
+        if key not in self.entries:
+            self.entries[key] = RunCounter()
+        return self.entries[key]
+
+    def __contains__(self, key):
+        return True
 

--- a/templates/bids-v1.json
+++ b/templates/bids-v1.json
@@ -333,12 +333,15 @@
 			"initialize": {
 				"Task": {
 					"acquisition.label": {
-						"$regex": "_task-(?P<value>[^-_]+)"
+						"$regex": "(^|_)task-(?P<value>[^-_]+)"
 					}
 				},
 				"Run": {
 					"acquisition.label": {
-						"$regex": "_run-(?P<value>\\d+)"
+						"$regex": "(^|_)run-(?P<value>[=+\\d]+)"
+					},
+					"$run_counter": {
+						"key": "anat.{file.info.BIDS.Task}"
 					}
 				}
 			}
@@ -358,12 +361,15 @@
 			"initialize": {
 				"Task": {
 					"acquisition.label": {
-						"$regex": "_task-(?P<value>[^-_]+)"
+						"$regex": "(^|_)task-(?P<value>[^-_]+)"
 					}
 				},
 				"Run": {
 					"acquisition.label": {
-						"$regex": "_run-(?P<value>\\d+)"
+						"$regex": "(^|_)run-(?P<value>[=+\\d]+)"
+					},
+					"$run_counter": {
+						"key": "functional.{file.info.BIDS.Task}"
 					}
 				},
 				"Modality": {
@@ -402,12 +408,15 @@
 			"initialize": {
 				"Task": {
 					"acquisition.label": {
-						"$regex": "_task-(?P<value>[^-_]+)"
+						"$regex": "(^|_)task-(?P<value>[^-_]+)"
 					}
 				},
 				"Run": {
 					"acquisition.label": {
-						"$regex": "_run-(?P<value>\\d+)"
+						"$regex": "(^|_)run-(?P<value>[=+\\d]+)"
+					},
+					"$run_counter": {
+						"key": "task_events.{file.info.BIDS.Task}"
 					}
 				}
 			}
@@ -427,7 +436,7 @@
 			"initialize": {
 				"Task": {
 					"acquisition.label": {
-						"$regex": "_task-(?P<value>[^-_]+)"
+						"$regex": "(^|_)task-(?P<value>[^-_]+)"
 					}
 				}
 			}
@@ -447,12 +456,15 @@
 			"initialize": {
 				"Task": {
 					"acquisition.label": {
-						"$regex": "_task-(?P<value>[^-_]+)"
+						"$regex": "(^|_)task-(?P<value>[^-_]+)"
 					}
 				},
 				"Run": {
 					"acquisition.label": {
-						"$regex": "_run-(?P<value>\\d+)"
+						"$regex": "(^|_)run-(?P<value>[=+\\d]+)"
+					},
+					"$run_counter": {
+						"key": "physio.{file.info.BIDS.Task}"
 					}
 				}
 			}
@@ -472,7 +484,10 @@
 			"initialize": {
 				"Run": {
 					"acquisition.label": {
-						"$regex": "_run-(?P<value>\\d+)"
+						"$regex": "(^|_)run-(?P<value>[=+\\d]+)"
+					},
+					"$run_counter": {
+						"key": "diffusion"
 					}
 				}
 			}
@@ -501,7 +516,10 @@
 				},
 				"Run": {
 					"acquisition.label": {
-						"$regex": "_run-(?P<value>\\d+)"
+						"$regex": "(^|_)run-(?P<value>[=+\\d]+)"
+					},
+					"$run_counter": {
+						"key": "field_map.{file.info.BIDS.Dir}"
 					}
 				}
 			}
@@ -521,7 +539,10 @@
 			"initialize": {
 				"Run": {
 					"acquisition.label": {
-						"$regex": "_run-(?P<value>\\d+)"
+						"$regex": "(^|_)run-(?P<value>[=+\\d+])"
+					},
+					"$run_counter": {
+						"key": "field_map"
 					}
 				}
 			}

--- a/tests/test_bidsify_flywheel.py
+++ b/tests/test_bidsify_flywheel.py
@@ -35,7 +35,7 @@ class BidsifyTestCases(unittest.TestCase):
         }
 
         # Call function
-        updated_string = bidsify_flywheel.process_string_template(auto_update_str, context)
+        updated_string = utils.process_string_template(auto_update_str, context)
 
         self.assertEqual(updated_string,
                 'sub-%s_ses-%s_bold.nii.gz' % (
@@ -60,7 +60,7 @@ class BidsifyTestCases(unittest.TestCase):
         }
 
         # Call function
-        updated_string = bidsify_flywheel.process_string_template(auto_update_str, context)
+        updated_string = utils.process_string_template(auto_update_str, context)
 
         self.assertEqual(updated_string,
                 '%s_%s_bold.nii.gz' % (
@@ -85,7 +85,7 @@ class BidsifyTestCases(unittest.TestCase):
         }
 
         # Call function
-        updated_string = bidsify_flywheel.process_string_template(auto_update_str, context)
+        updated_string = utils.process_string_template(auto_update_str, context)
         # Assert function honors the optional 'sub-<subject.code>'
         self.assertEqual(updated_string,
                 '_ses-%s_acq-%s_bold.nii.gz' % (
@@ -109,7 +109,7 @@ class BidsifyTestCases(unittest.TestCase):
         }
 
         # Call function
-        updated_string = bidsify_flywheel.process_string_template(auto_update_str, context)
+        updated_string = utils.process_string_template(auto_update_str, context)
         # Assert function honors the optional labels
         self.assertEqual(updated_string,
                 'sub-123_ses-456')
@@ -132,7 +132,7 @@ class BidsifyTestCases(unittest.TestCase):
         }
 
         # Call function
-        updated_string = bidsify_flywheel.process_string_template(auto_update_str, context)
+        updated_string = utils.process_string_template(auto_update_str, context)
         # Assert string as expected
         self.assertEqual(updated_string,
                 'sub-%s_ses-%s_task-%s_%s%s' % (
@@ -161,7 +161,7 @@ class BidsifyTestCases(unittest.TestCase):
         }
 
         # Call function
-        updated_string = bidsify_flywheel.process_string_template(auto_update_str, context)
+        updated_string = utils.process_string_template(auto_update_str, context)
         # Assert function honors the optional 'sub-<subject.code>'
         self.assertEqual(updated_string,
                 'sub-<subject.code>_ses-%s' % (
@@ -186,7 +186,7 @@ class BidsifyTestCases(unittest.TestCase):
         }
 
         # Call function
-        updated_string = bidsify_flywheel.process_string_template(auto_update_str, context)
+        updated_string = utils.process_string_template(auto_update_str, context)
         # Assert function honors the optional 'sub-<subject.code>'
         self.assertEqual(updated_string,
                 'sub-<subject.code>_ses-%s' % (

--- a/tests/test_bidsify_flywheel.py
+++ b/tests/test_bidsify_flywheel.py
@@ -321,7 +321,8 @@ class BidsifyTestCases(unittest.TestCase):
             'project': None,
             'subject': {u'code': u'001'},
             'session': {u'label': u'sesTEST'},
-            'acquisition': {u'label': u'acqTEST'},
+            'run_counters': utils.RunCounterMap(),
+            'acquisition': {u'label': u'acq_task-TEST_run-+'},
             'file': {u'measurements': [u'functional'],
                     u'type': u'nifti',
                         },
@@ -334,10 +335,10 @@ class BidsifyTestCases(unittest.TestCase):
             'info': {
                 'BIDS': {
                     'template': 'func_file',
-                    'Filename': u'sub-001_ses-sestest_task-{file.info.BIDS.Task}_bold.nii.gz',
+                    'Filename': u'sub-001_ses-sestest_task-TEST_run-1_bold.nii.gz',
                     'Folder': 'func', 'Path': u'sub-001/ses-sestest/func',
-                    'Acq': '', 'Task': '', 'Modality': 'bold',
-                    'Rec': '', 'Run': '', 'Echo': ''
+                    'Acq': '', 'Task': 'TEST', 'Modality': 'bold',
+                    'Rec': '', 'Run': '1', 'Echo': ''
                     }
                 },
             u'measurements': [u'functional'], u'type': u'nifti'}


### PR DESCRIPTION
This feature allows specifying a `+` instead of a run number in the acquisition label. Run numbers set in this way will be incremented from 1 across like acquisitions for a session.