### PR TITLE
Intended For

### DIFF
--- a/curate_bids.py
+++ b/curate_bids.py
@@ -189,12 +189,8 @@ def curate_bids_tree(fw, project, reset=False, template_file=None, update=True):
     # 2. Perform any path resolutions
     session = None
     for context in project.context_iter():
-        ctype = context['container_type']
-        if ctype == 'session':
-            session = context['session']
-        if session is not None:
-            # Resolution
-            bidsify_flywheel.process_resolvers(session, context, template)
+        # Resolution
+        bidsify_flywheel.process_resolvers(context, template)
 
     # 3. Send updates to server
     if update:

--- a/supporting_files/bidsify_flywheel.py
+++ b/supporting_files/bidsify_flywheel.py
@@ -50,6 +50,8 @@ def add_properties(properties, obj, measurements):
                 obj[key] = "default"
         elif proptype == "object":
             obj[key] = properties[key].get('default', {})
+        elif 'default' in properties[key]:
+                obj[key] = properties[key]['default']
     return(obj)
 
 

--- a/supporting_files/bidsify_flywheel.py
+++ b/supporting_files/bidsify_flywheel.py
@@ -120,6 +120,14 @@ def process_matching_templates(context, template=templates.DEFAULT_TEMPLATE):
     return container
 
 def process_resolvers(session, context, template=templates.DEFAULT_TEMPLATE):
+    """
+    Perform second stage path resolution based on template rules
+
+    Args:
+        session (TreeNode): The session node to search within
+        context (dict): The context to perform path resolution on
+        template (Template): The template
+    """
     namespace = template.namespace
 
     container_type = context['container_type']
@@ -128,9 +136,12 @@ def process_resolvers(session, context, template=templates.DEFAULT_TEMPLATE):
     if (('info' not in container) or (namespace not in container['info']) or ('template' not in container['info'][namespace])):
         return
     
+    # Determine the applied template name
     template_name = container['info'][namespace]['template']
+    # Get a list of resolvers that apply to this template
     resolvers = template.resolver_map.get(template_name, [])
 
+    # Apply each resolver
     for resolver in resolvers:
         resolver.resolve(session, context)
 

--- a/supporting_files/bidsify_flywheel.py
+++ b/supporting_files/bidsify_flywheel.py
@@ -121,7 +121,7 @@ def process_matching_templates(context, template=templates.DEFAULT_TEMPLATE):
 
     return container
 
-def process_resolvers(session, context, template=templates.DEFAULT_TEMPLATE):
+def process_resolvers(context, template=templates.DEFAULT_TEMPLATE):
     """
     Perform second stage path resolution based on template rules
 
@@ -145,7 +145,7 @@ def process_resolvers(session, context, template=templates.DEFAULT_TEMPLATE):
 
     # Apply each resolver
     for resolver in resolvers:
-        resolver.resolve(session, context)
+        resolver.resolve(context)
 
 
 def ensure_info_exists(context, template=templates.DEFAULT_TEMPLATE):

--- a/supporting_files/project_tree.py
+++ b/supporting_files/project_tree.py
@@ -67,9 +67,10 @@ class TreeNode(collections.MutableMapping):
         # Yield the current context before processing children
         yield context
 
+        context['parent_container_type'] = self.type
         for child in self.children:
-            context['parent_container_type'] = self.type
-            for ctx in child.context_iter(context):
+            context_copy = context.copy()
+            for ctx in child.context_iter(context_copy):
                 yield ctx
 
     def __len__(self):

--- a/supporting_files/resolver.py
+++ b/supporting_files/resolver.py
@@ -2,10 +2,26 @@ import re
 import utils
 
 class Filter:
+    """
+    Simple wrapper for a matching filter that can be applied to a context.
+
+    Args:
+        fields(dict): The field to value(s) mapping.
+    """
     def __init__(self, fields):
         self.fields = fields
 
     def test(self, context):
+        """
+        Test context to see if it passes this filter. Top-level clauses (properties) are
+        logically ANDed, and lists of values are logically ORed.
+
+        Args:
+            context (dict): The context to check
+
+        Returns:
+            bool: True if every top level clause matched
+        """
         for prop, filter_value in self.fields.items():
             prop_val = utils.dict_lookup(context, prop)
             if isinstance(filter_value, list):
@@ -18,6 +34,22 @@ class Filter:
 
 
 class Resolver:
+    """
+    Compiled resolver rule
+
+    Args:
+        namespace (str): The template namespace
+        resolverDef (dict): The resolver properties dictionary
+
+    Attributes:
+        namespace: The template namespace
+        id: The optional resolver id
+        templates: The list of templates this resolver applies to
+        update_field: The field to be updated with the resolved result
+        filter_field: The field that contains the user-defined filter
+        container_type: The type of container this resolver should match
+        format: The format string for resolved values
+    """
     def __init__(self, namespace, resolverDef): 
         self.namespace = namespace
         self.id = resolverDef.get('id')
@@ -28,6 +60,13 @@ class Resolver:
         self.format = resolverDef.get('format')
 
     def resolve(self, session, context):
+        """
+        Resolve update_field for context by matching and formatting children of session.
+
+        Args:
+            session (TreeNode): The session to search within
+            context (dict): The context to update
+        """
         results = []
 
         # Determine filter fields, and add namespace prefix for matching
@@ -47,8 +86,5 @@ class Resolver:
         
         # Finally update the field specified
         utils.dict_set(context, self.update_field, results)
-
-
-    
 
     

--- a/supporting_files/resolver.py
+++ b/supporting_files/resolver.py
@@ -1,0 +1,54 @@
+import re
+import utils
+
+class Filter:
+    def __init__(self, fields):
+        self.fields = fields
+
+    def test(self, context):
+        for prop, filter_value in self.fields.items():
+            prop_val = utils.dict_lookup(context, prop)
+            if isinstance(filter_value, list):
+                if prop_val not in filter_value:
+                    return False
+            else:
+                if prop_val != filter_value:
+                    return False
+        return True
+
+
+class Resolver:
+    def __init__(self, namespace, resolverDef): 
+        self.namespace = namespace
+        self.id = resolverDef.get('id')
+        self.templates = resolverDef.get('templates', [])
+        self.update_field = resolverDef.get('update')
+        self.filter_field = resolverDef.get('filter')
+        self.container_type = resolverDef.get('type')
+        self.format = resolverDef.get('format')
+
+    def resolve(self, session, context):
+        results = []
+
+        # Determine filter fields, and add namespace prefix for matching
+        filter_fields = utils.dict_lookup(context, self.filter_field, {})
+        fields = {}
+        if self.container_type:
+            fields['container_type'] = self.container_type
+        for k, v in filter_fields.items():
+            key = '{}.info.{}.{}'.format(self.container_type, self.namespace, k)
+            fields[key] = v
+        filt = Filter(fields)
+
+        # Iterate through the contexts in the session, collecting matches
+        for ctx in session.context_iter():
+            if filt.test(ctx):
+                results.append(utils.process_string_template(self.format, ctx))
+        
+        # Finally update the field specified
+        utils.dict_set(context, self.update_field, results)
+
+
+    
+
+    

--- a/supporting_files/utils.py
+++ b/supporting_files/utils.py
@@ -64,7 +64,7 @@ def get_extension(fname):
         ext = ext.group()
     return ext
 
-def dict_lookup(obj, value):
+def dict_lookup(obj, value, default=None):
     # For now, we don't support escaping of dots
     parts = value.split('.')
     curr = obj
@@ -74,9 +74,21 @@ def dict_lookup(obj, value):
         elif isinstance(curr, list) and int(part) < len(curr):
             curr = curr[int(part)]
         else:
-            curr = None
+            curr = default
             break
     return curr
+
+def dict_set(obj, key, value):
+    parts = key.split('.')
+    curr = obj
+    for part in parts[:-1]:
+        if isinstance(curr, (dict, collections.Mapping)) and part in curr:
+            curr = curr[part]
+        elif isinstance(curr, list) and int(part) < len(curr):
+            curr = curr[int(part)]
+        else:
+            raise ValueError('Could not set value for key: ' + key)
+    curr[parts[-1]] = value
 
 def normalize_strings(obj):
     if isinstance(obj, basestring):

--- a/templates/bids-v1.json
+++ b/templates/bids-v1.json
@@ -26,6 +26,13 @@
 			"default": "",
 			"minLength": 1
 		},
+		"IntendedFor": {
+			"type": "object",
+			"title": "IntendedFor",
+			"default": {
+				"Folder": ["anat", "func"]
+			}
+		},
 		"Mod": {
 			"type": "string", 
 			"title": "Mod Label", 
@@ -226,6 +233,7 @@
 				"Acq": {"$ref":"#/definitions/Acq"},
 				"Run": {"$ref":"#/definitions/Run"},
 				"Dir": {"type": "string", "title": "Dir Label", "default": ""},
+				"IntendedFor": {"$ref":"#/definitions/IntendedFor"},
 				"Modality": {"type": "string", "title": "Modality Label", "default": "fieldmap",
 					"enum": [
 						"phasediff",
@@ -252,6 +260,7 @@
 				"Acq": {"type": "string", "label": "Acq Label", "default": ""},
 				"Run": {"type": "string", "label": "Run Index", "default": ""},
 				"Dir": {"type": "string", "label": "Dir Label", "default": ""},
+				"IntendedFor": {"$ref":"#/definitions/IntendedFor"},
 				"Modality": {"type": "string", "label": "Modality Label", "default": "epi",
 					"enum": [
 						"phasediff",
@@ -571,6 +580,16 @@
 					"$in": ["source code", "JSON"]
 				}
 			}
+		}
+	],
+	"resolvers": [
+		{
+			"id": "bids_intended_for",
+			"templates": [ "fieldmap_file", "fieldmap_phase_encoded_file" ],
+			"update": "file.info.IntendedFor",
+			"filter": "file.info.BIDS.IntendedFor",
+			"type": "file",
+			"format": "{file.info.BIDS.Folder}/{file.info.BIDS.Filename}"
 		}
 	]
 }

--- a/templates/bids-v1.json
+++ b/templates/bids-v1.json
@@ -589,6 +589,7 @@
 			"templates": [ "fieldmap_file", "fieldmap_phase_encoded_file" ],
 			"update": "file.info.IntendedFor",
 			"filter": "file.info.BIDS.IntendedFor",
+			"resolveFor": "session",
 			"type": "file",
 			"format": "{file.info.BIDS.Folder}/{file.info.BIDS.Filename}"
 		}

--- a/templates/bids-v1.json
+++ b/templates/bids-v1.json
@@ -27,11 +27,12 @@
 			"minLength": 1
 		},
 		"IntendedFor": {
-			"type": "object",
+			"type": "array",
 			"title": "IntendedFor",
-			"default": {
-				"Folder": ["anat", "func"]
-			}
+			"default": [
+				{ "Folder": "anat" },
+				{ "Folder": "func" }
+			]
 		},
 		"Mod": {
 			"type": "string", 

--- a/tests/test_bidsify_flywheel.py
+++ b/tests/test_bidsify_flywheel.py
@@ -553,7 +553,8 @@ class BidsifyTestCases(unittest.TestCase):
                     'template': 'fieldmap_file',
                     'Filename': u'sub-001_ses-sestest_fieldmap.nii.gz',
                     'Folder': 'fmap', 'Path': u'sub-001/ses-sestest/fmap',
-                    'Acq': '', 'Run': '', 'Dir': '', 'Modality': 'fieldmap'
+                    'Acq': '', 'Run': '', 'Dir': '', 'Modality': 'fieldmap',
+                    'IntendedFor': {'Folder': ['anat', 'func']}
                     }
                 },
             u'measurements': [u'field_map'], u'type': u'nifti'}
@@ -586,7 +587,8 @@ class BidsifyTestCases(unittest.TestCase):
                     'template': 'fieldmap_phase_encoded_file',
                     'Filename': u'sub-001_ses-sestest_dir-PA_epi.nii.gz',
                     'Folder': 'fmap', 'Path': u'sub-001/ses-sestest/fmap',
-                    'Acq': '', 'Run': '', 'Dir': 'PA', 'Modality': 'epi'
+                    'Acq': '', 'Run': '', 'Dir': 'PA', 'Modality': 'epi',
+                    'IntendedFor': {'Folder': ['anat', 'func']}
                     },
                     'PhaseEncodingDirection': 'j'
                 },

--- a/tests/test_bidsify_flywheel.py
+++ b/tests/test_bidsify_flywheel.py
@@ -554,7 +554,10 @@ class BidsifyTestCases(unittest.TestCase):
                     'Filename': u'sub-001_ses-sestest_fieldmap.nii.gz',
                     'Folder': 'fmap', 'Path': u'sub-001/ses-sestest/fmap',
                     'Acq': '', 'Run': '', 'Dir': '', 'Modality': 'fieldmap',
-                    'IntendedFor': {'Folder': ['anat', 'func']}
+                    'IntendedFor': [
+                        {'Folder': 'anat'},
+                        {'Folder': 'func'}
+                    ]
                     }
                 },
             u'measurements': [u'field_map'], u'type': u'nifti'}
@@ -588,7 +591,10 @@ class BidsifyTestCases(unittest.TestCase):
                     'Filename': u'sub-001_ses-sestest_dir-PA_epi.nii.gz',
                     'Folder': 'fmap', 'Path': u'sub-001/ses-sestest/fmap',
                     'Acq': '', 'Run': '', 'Dir': 'PA', 'Modality': 'epi',
-                    'IntendedFor': {'Folder': ['anat', 'func']}
+                    'IntendedFor': [
+                        {'Folder': 'anat'},
+                        {'Folder': 'func'}
+                    ]
                     },
                     'PhaseEncodingDirection': 'j'
                 },


### PR DESCRIPTION
This commit introduces the idea of "Resolvers" to the templates. Resolvers work by performing a filter of all nodes in a session, then formatting the results into a list and finally updating a property on a context.

This allows the user to specify something like:
```javascript
{
  "IntendedFor": [
    {"Folder": "func"}
  ]
}
```

Which will match all files in the `func` folder belonging to the current session.
Default is to match all `anat` and `func` files for fieldmaps.

Closes #52 