### PR TITLE
Regex in where clause doesn't give error anymore

### DIFF
--- a/supporting_files/templates.py
+++ b/supporting_files/templates.py
@@ -362,8 +362,9 @@ def processValueMatch(value, match):
                         return True
 
                 return False
-
-            return regex.search(str(value)) is not None
+            if value is None:
+                return False
+            return regex.search(value) is not None
 
     else:
         # Direct match

--- a/supporting_files/templates.py
+++ b/supporting_files/templates.py
@@ -363,7 +363,7 @@ def processValueMatch(value, match):
 
                 return False
 
-            return regex.search(value) is not None
+            return regex.search(str(value)) is not None
 
     else:
         # Direct match

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -102,4 +102,14 @@ class RuleTestCases(unittest.TestCase):
         rule.initializeProperties(info, context)
         self.assertEqual( info, { 'Property': 'the_New_string'})
 
-
+    def test_rule_where_regex_match(self):
+        rule = templates.Rule({
+            'template': 'test',
+            'where': {
+                'x': {
+                    "$regex": "topup"
+                }
+            }
+        })
+        context = { 'x': 'string_with topup in it' }
+        self.assertTrue(rule.test(context))


### PR DESCRIPTION
When curation tried to match against a file that didn't have the value, it would try to send None as the argument for regex.search() and resulted in an error:
```
  File "code/curate_bids.py", line 233, in <module>
    curate_bids_dir(fw, project_id, reset=args.reset, template_file=args.template_file)
  File "code/curate_bids.py", line 128, in curate_bids_dir
    curate_bids_tree(fw, project, reset, template_file, True)
  File "code/curate_bids.py", line 167, in curate_bids_tree
    bidsify_flywheel.process_matching_templates(context, template)
  File "/code/supporting_files/bidsify_flywheel.py", line 95, in process_matching_templates
    if rule.test(context):
  File "/code/supporting_files/templates.py", line 209, in test
    return test_where_clause(self.conditions, context)
  File "/code/supporting_files/templates.py", line 328, in test_where_clause
    if not processValueMatch(value, match):
  File "/code/supporting_files/templates.py", line 368, in processValueMatch
    return regex.search(value) is not None
```