### PR TITLE
Fix the run plus indexing convention

### DIFF
--- a/supporting_files/templates.py
+++ b/supporting_files/templates.py
@@ -253,9 +253,15 @@ def apply_initializers(initializers, info, context):
                     if value is not None:
                         # Regex matching must provide a 'value' group
                         if '$regex' in valueSpec:
-                            m = re.search(valueSpec['$regex'], value)
-                            if m is not None:
-                                resolvedValue = m.group('value')
+                            regex_list = valueSpec['$regex']
+                            if not isinstance(regex_list, list):
+                                regex_list = [regex_list]
+
+                            for regex in regex_list:
+                                m = re.search(regex, value)
+                                if m is not None:
+                                    resolvedValue = m.group('value')
+                                    break
                         # 'take' will just copy the value
                         elif '$take' in valueSpec and valueSpec['$take']:
                             resolvedValue = value

--- a/templates/bids-v1.json
+++ b/templates/bids-v1.json
@@ -359,7 +359,10 @@
 				},
 				"Run": {
 					"acquisition.label": {
-						"$regex": "(^|_)run-(?P<value>[=+\\d]+)"
+						"$regex": [
+							"(^|_)run-(?P<value>\\d+)",
+							"(^|_)run(?P<value>[=+])"
+						]
 					},
 					"$run_counter": {
 						"key": "anat.{file.info.BIDS.Task}"
@@ -387,7 +390,10 @@
 				},
 				"Run": {
 					"acquisition.label": {
-						"$regex": "(^|_)run-(?P<value>[=+\\d]+)"
+						"$regex": [
+							"(^|_)run-(?P<value>\\d+)",
+							"(^|_)run(?P<value>[=+])"
+						]
 					},
 					"$run_counter": {
 						"key": "functional.{file.info.BIDS.Task}"
@@ -434,7 +440,10 @@
 				},
 				"Run": {
 					"acquisition.label": {
-						"$regex": "(^|_)run-(?P<value>[=+\\d]+)"
+						"$regex": [
+							"(^|_)run-(?P<value>\\d+)",
+							"(^|_)run(?P<value>[=+])"
+						]
 					},
 					"$run_counter": {
 						"key": "task_events.{file.info.BIDS.Task}"
@@ -482,7 +491,10 @@
 				},
 				"Run": {
 					"acquisition.label": {
-						"$regex": "(^|_)run-(?P<value>[=+\\d]+)"
+						"$regex": [
+							"(^|_)run-(?P<value>\\d+)",
+							"(^|_)run(?P<value>[=+])"
+						]
 					},
 					"$run_counter": {
 						"key": "physio.{file.info.BIDS.Task}"
@@ -505,7 +517,10 @@
 			"initialize": {
 				"Run": {
 					"acquisition.label": {
-						"$regex": "(^|_)run-(?P<value>[=+\\d]+)"
+						"$regex": [
+							"(^|_)run-(?P<value>\\d+)",
+							"(^|_)run(?P<value>[=+])"
+						]
 					},
 					"$run_counter": {
 						"key": "diffusion"
@@ -537,7 +552,10 @@
 				},
 				"Run": {
 					"acquisition.label": {
-						"$regex": "(^|_)run-(?P<value>[=+\\d]+)"
+						"$regex": [
+							"(^|_)run-(?P<value>\\d+)",
+							"(^|_)run(?P<value>[=+])"
+						]
 					},
 					"$run_counter": {
 						"key": "field_map.{file.info.BIDS.Dir}"
@@ -560,7 +578,10 @@
 			"initialize": {
 				"Run": {
 					"acquisition.label": {
-						"$regex": "(^|_)run-(?P<value>[=+\\d+])"
+						"$regex": [
+							"(^|_)run-(?P<value>\\d+)",
+							"(^|_)run(?P<value>[=+])"
+						]
 					},
 					"$run_counter": {
 						"key": "field_map"

--- a/tests/test_bidsify_flywheel.py
+++ b/tests/test_bidsify_flywheel.py
@@ -322,7 +322,7 @@ class BidsifyTestCases(unittest.TestCase):
             'subject': {u'code': u'001'},
             'session': {u'label': u'sesTEST'},
             'run_counters': utils.RunCounterMap(),
-            'acquisition': {u'label': u'acq_task-TEST_run-+'},
+            'acquisition': {u'label': u'acq_task-TEST_run+'},
             'file': {u'measurements': [u'functional'],
                     u'type': u'nifti',
                         },


### PR DESCRIPTION
Basically, `run-+` should be `run+`. This update will also allow template creators to specify multiple regexp matches per intializer rule.