### PR TITLE
Only bids relevant dicoms are matched as source data

### DIFF
--- a/templates/bids-v1.json
+++ b/templates/bids-v1.json
@@ -638,10 +638,20 @@
 				"container_type": "file",
         		"file.type": {
 					"$in": ["dicom", "DICOM"]
+				},
+				"file.measurements": {
+					"$in": [
+						"anatomy_t1w", "anatomy_t2w", "anatomy_t1wrho",
+						"map_t1w", "map_t2w", "anatomy_t2star", "anatomy_flair",
+						"anatomy_flash", "anatomy_pd", "map_pd", "anatomy_pdt2",
+						"anatomy_t1w_inplane", "anatomy_t2w_inplane", "angio",
+						"defacemask", "swi", "functional", "behavioral",
+						"physio", "diffusion", "field_map"
+					]
 				}
 			},
 			"initialize": {
-				"Filename": { 
+				"Filename": {
 					"file.name": { "$take": true }
 				}
 			}

--- a/tests/test_bidsify_flywheel.py
+++ b/tests/test_bidsify_flywheel.py
@@ -629,6 +629,33 @@ class BidsifyTestCases(unittest.TestCase):
             u'type': u'dicom'}
         self.assertEqual(container, container_expected)
 
+    def test_process_matching_templates_non_bids_dicom(self):
+        # Define context
+        context = {
+            'container_type': 'file',
+            'parent_container_type': 'acquisition',
+            'project': {u'label': 'hello'},
+            'subject': {u'code': u'001'},
+            'session': {u'label': u'sesTEST', 'info': {'BIDS': {'Label': u'sesTEST'}}},
+            'acquisition': {u'label': u'acqTEST', u'_id': u'09090'},
+            'file': {
+                u'name': u'4784_1_1_localizer',
+                u'measurements': [u'localizer'],
+                u'type': u'dicom'
+            },
+            'ext': '.dcm.zip'
+        }
+        # Call function
+        container = bidsify_flywheel.process_matching_templates(context)
+        print container
+        # Define expected container
+        container_expected = {
+            u'name': u'4784_1_1_localizer',
+            u'measurements': [u'localizer'],
+            u'type': u'dicom'
+        }
+        self.assertEqual(container, container_expected)
+
     def test_resolve_initial_dicom_field_values_from_filename(self):
         # Define context
         context = {


### PR DESCRIPTION
Only dicoms that have measurements that a nifti file would be matched as a BIDS data type are matched as source data.