### PR TITLE
Ignore export

### DIFF
--- a/curate_bids.py
+++ b/curate_bids.py
@@ -114,6 +114,9 @@ def update_meta_info(fw, context):
     # Modify session
     elif context['container_type'] == 'session':
         fw.replace_session_info(context['session']['_id'], context['session']['info'])
+    # Modify acquisition
+    elif context['container_type'] == 'acquisition':
+        fw.replace_acquisition_info(context['acquisition']['_id'], context['acquisition']['info'])
     # Cannot determine container type
     else:
         logger.info('Cannot determine container type: ' + context['container_type'])
@@ -180,6 +183,9 @@ def curate_bids_tree(fw, project, reset=False, template_file=None, update=True):
 
             # Add run_counter
             context['run_counters'] = utils.RunCounterMap()
+
+        elif ctype == 'acquisition':
+            bidsify_flywheel.process_matching_templates(context, template)
 
         elif ctype == 'file':
             if parent_ctype == 'project' and PROJECT_TEMPLATE_FILE_NAME_REGEX.search(context['file']['name']):

--- a/export_bids.py
+++ b/export_bids.py
@@ -75,6 +75,9 @@ def is_file_excluded(f, namespace, src_data):
 
     return False
 
+def is_container_excluded(container, namespace):
+    return isinstance(container.get('info', {}).get(namespace, {}), dict) and container.get('info', {}).get(namespace, {}).get('Ignore')
+
 def warn_if_bids_invalid(f, namespace):
     """
     Logs a warning iff info.BIDS.valid = false
@@ -268,7 +271,7 @@ def download_bids_dir(fw, project_id, outdir, src_data=False,
             continue
 
         # Skip session if BIDS.Ignore is True
-        if isinstance(proj_ses.get('info', {}).get('BIDS', {}), dict) and proj_ses.get('info', {}).get('BIDS', {}).get('Ignore'):
+        if is_container_excluded(proj_ses, namespace):
             continue
 
         # Skip subject if we're filtering subjects
@@ -306,7 +309,7 @@ def download_bids_dir(fw, project_id, outdir, src_data=False,
         for ses_acq in session_acqs:
 
             # Skip if BIDS.Ignore is True
-            if isinstance(ses_acq.get('info', {}).get('BIDS', {}), dict) and ses_acq.get('info', {}).get('BIDS', {}).get('Ignore'):
+            if is_container_excluded(ses_acq, namespace):
                 continue
             # Get true acquisition, in order to access file info
             acq = fw.get_acquisition(ses_acq['_id'])

--- a/export_bids.py
+++ b/export_bids.py
@@ -267,6 +267,10 @@ def download_bids_dir(fw, project_id, outdir, src_data=False,
         if sessions and proj_ses.get('label') not in sessions:
             continue
 
+        # Skip session if BIDS.Ignore is True
+        if isinstance(proj_ses.get('info', {}).get('BIDS', {}), dict) and proj_ses.get('info', {}).get('BIDS', {}).get('Ignore'):
+            continue
+
         # Skip subject if we're filtering subjects
         if subjects:
             subj_code = proj_ses.get('subject', {}).get('code')
@@ -300,6 +304,10 @@ def download_bids_dir(fw, project_id, outdir, src_data=False,
         # Get acquisitions
         session_acqs = fw.get_session_acquisitions(proj_ses['_id'])
         for ses_acq in session_acqs:
+
+            # Skip if BIDS.Ignore is True
+            if isinstance(ses_acq.get('info', {}).get('BIDS', {}), dict) and ses_acq.get('info', {}).get('BIDS', {}).get('Ignore'):
+                continue
             # Get true acquisition, in order to access file info
             acq = fw.get_acquisition(ses_acq['_id'])
             # Iterate over acquistion files

--- a/export_bids.py
+++ b/export_bids.py
@@ -76,7 +76,9 @@ def is_file_excluded(f, namespace, src_data):
     return False
 
 def is_container_excluded(container, namespace):
-    return isinstance(container.get('info', {}).get(namespace, {}), dict) and container.get('info', {}).get(namespace, {}).get('Ignore')
+    meta_info = container.get('info', {}).get(namespace, {})
+    if isinstance(meta_info, dict):
+        return meta_info.get('ignore', False)
 
 def warn_if_bids_invalid(f, namespace):
     """

--- a/export_bids.py
+++ b/export_bids.py
@@ -65,7 +65,7 @@ def is_file_excluded(f, namespace, src_data):
     if not metadata:
         return True
 
-    if parse_bool(metadata.get('exclude', False)):
+    if parse_bool(metadata.get('ignore', False)):
         return True
 
     if not src_data:

--- a/supporting_files/bidsify_flywheel.py
+++ b/supporting_files/bidsify_flywheel.py
@@ -111,6 +111,8 @@ def process_matching_templates(context, template=templates.DEFAULT_TEMPLATE, upl
                 obj = container['info'].get(namespace, {})
                 container['info'][namespace] = add_properties(templateDef['properties'], obj, container.get('measurements'))
                 obj['template'] = rule.template
+                if container_type in ['session', 'acquisition', 'file']:
+                    obj['ignore'] = False
                 rule.initializeProperties(obj, context)
                 if rule.id:
                     template.apply_custom_initialization(rule.id, obj, context)

--- a/templates/bids-v1.json
+++ b/templates/bids-v1.json
@@ -14,9 +14,14 @@
 			"default": "",
 			"pattern": "^[a-zA-Z0-9]*$"
 		},
+		"Ignore": {
+			"type": "boolean",
+			"title": "Ignore",
+			"default": false
+		},
 		"Echo": {
-			"type": "string", 
-			"title": "Echo Index", 
+			"type": "string",
+			"title": "Echo Index",
 			"default": "",
 			"pattern": "^[0-9]*$"
 		},
@@ -86,7 +91,8 @@
 		"session": {
 			"description": "BIDS session template",
 			"properties": {
-				"Label": {"type": "string", "title": "Label", "default": "", "auto_update": "{session.label}"}
+				"Label": {"type": "string", "title": "Label", "default": "", "auto_update": "{session.label}"},
+				"Ignore": {"$ref": "#/definitions/Ignore"}
 			},
 			"required": []
 		},
@@ -100,6 +106,13 @@
 					"auto_update": "sub-<subject.code>[/ses-<session.info.BIDS.Label>]"}
 			},
 			"required": ["Filename"]
+		},
+		"acquisition": {
+			"description": "BIDS session template",
+			"properties": {
+				"Ignore": {"$ref": "#/definitions/Ignore"}
+			},
+			"required": []
 		},
 		"acquisition_file": {
 			"description": "BIDS acquisition file template",
@@ -344,6 +357,13 @@
 			"where": {
 				"container_type": "file",
 				"parent_container_type": "session"
+			}
+		},
+		{
+			"id": "bids_acquisition",
+			"template": "acquisition",
+			"where": {
+				"container_type": "acquisition"
 			}
 		},
 		{

--- a/templates/bids-v1.json
+++ b/templates/bids-v1.json
@@ -14,11 +14,6 @@
 			"default": "",
 			"pattern": "^[a-zA-Z0-9]*$"
 		},
-		"Ignore": {
-			"type": "boolean",
-			"title": "Ignore",
-			"default": false
-		},
 		"Echo": {
 			"type": "string",
 			"title": "Echo Index",
@@ -91,8 +86,7 @@
 		"session": {
 			"description": "BIDS session template",
 			"properties": {
-				"Label": {"type": "string", "title": "Label", "default": "", "auto_update": "{session.label}"},
-				"Ignore": {"$ref": "#/definitions/Ignore"}
+				"Label": {"type": "string", "title": "Label", "default": "", "auto_update": "{session.label}"}
 			},
 			"required": []
 		},
@@ -110,7 +104,6 @@
 		"acquisition": {
 			"description": "BIDS session template",
 			"properties": {
-				"Ignore": {"$ref": "#/definitions/Ignore"}
 			},
 			"required": []
 		},

--- a/tests/test_bidsify_flywheel.py
+++ b/tests/test_bidsify_flywheel.py
@@ -275,7 +275,8 @@ class BidsifyTestCases(unittest.TestCase):
                     'Filename': u'sub-001_ses-sestest_T1w.nii.gz',
                     'Path': u'sub-001/ses-sestest/anat', 'Folder': 'anat',
                     'Run': '', 'Acq': '', 'Ce': '', 'Rec': '',
-                    'Modality': 'T1w', 'Mod': ''
+                    'Modality': 'T1w', 'Mod': '',
+                    'ignore': False
                     }
                 },
             u'measurements': [u'anatomy_t1w'], u'type': u'nifti'}
@@ -306,7 +307,8 @@ class BidsifyTestCases(unittest.TestCase):
                     'Filename': u'sub-001_ses-sestest_T2w.nii.gz',
                     'Path': u'sub-001/ses-sestest/anat', 'Folder': 'anat',
                     'Run': '', 'Acq': '', 'Ce': '', 'Rec': '',
-                    'Modality': 'T2w', 'Mod': ''
+                    'Modality': 'T2w', 'Mod': '',
+                    'ignore': False
                     }
                 },
             u'measurements': [u'anatomy_t2w'], u'type': u'nifti'}
@@ -338,7 +340,8 @@ class BidsifyTestCases(unittest.TestCase):
                     'Filename': u'sub-001_ses-sestest_task-TEST_run-1_bold.nii.gz',
                     'Folder': 'func', 'Path': u'sub-001/ses-sestest/func',
                     'Acq': '', 'Task': 'TEST', 'Modality': 'bold',
-                    'Rec': '', 'Run': '1', 'Echo': ''
+                    'Rec': '', 'Run': '1', 'Echo': '',
+                    'ignore': False
                     }
                 },
             u'measurements': [u'functional'], u'type': u'nifti'}
@@ -369,7 +372,8 @@ class BidsifyTestCases(unittest.TestCase):
                     'Filename': u'sub-001_ses-sestest_task-{file.info.BIDS.Task}_events.tsv',
                     'Folder': 'func', 'Path': u'sub-001/ses-sestest/func',
                     'Acq': '', 'Task': '',
-                    'Rec': '', 'Run': '', 'Echo': ''
+                    'Rec': '', 'Run': '', 'Echo': '',
+                    'ignore': False
                     }
                 },
             u'measurements': [u'functional'], u'type': u'tabular data'}
@@ -398,7 +402,8 @@ class BidsifyTestCases(unittest.TestCase):
                 'BIDS': {
                     'template': 'beh_events_file',
                     'Filename': u'sub-001_ses-sestest_task-{file.info.BIDS.Task}_events.tsv',
-                    'Folder': 'beh', 'Path': u'sub-001/ses-sestest/beh', 'Task': ''
+                    'Folder': 'beh', 'Path': u'sub-001/ses-sestest/beh', 'Task': '',
+                    'ignore': False
                     }
                 },
             u'measurements': [u'behavioral'], u'type': u'tabular data'}
@@ -433,7 +438,8 @@ class BidsifyTestCases(unittest.TestCase):
                     'Rec': '',
                     'Recording': '',
                     'Run': '',
-                    'Echo': ''
+                    'Echo': '',
+                    'ignore': False
                     }
                 },
             u'measurements': [u'physio'], u'type': u'tabular data'}
@@ -463,7 +469,8 @@ class BidsifyTestCases(unittest.TestCase):
                     'template': 'diffusion_file',
                     'Filename': u'sub-001_ses-sestest_dwi.nii.gz',
                     'Path': u'sub-001/ses-sestest/dwi', 'Folder': 'dwi',
-                     'Modality': 'dwi', 'Acq': '', 'Run': ''
+                     'Modality': 'dwi', 'Acq': '', 'Run': '',
+                    'ignore': False
                     }
                 },
             u'measurements': [u'diffusion'], u'type': u'nifti'}
@@ -493,7 +500,8 @@ class BidsifyTestCases(unittest.TestCase):
                     'template': 'diffusion_file',
                     'Filename': u'sub-001_ses-sestest_dwi.bval',
                     'Path': u'sub-001/ses-sestest/dwi', 'Folder': 'dwi',
-                     'Modality': 'dwi', 'Acq': '', 'Run': ''
+                     'Modality': 'dwi', 'Acq': '', 'Run': '',
+                    'ignore': False
                     }
                 },
             u'measurements': [u'diffusion'], u'type': u'bval'}
@@ -523,7 +531,8 @@ class BidsifyTestCases(unittest.TestCase):
                     'template': 'diffusion_file',
                     'Filename': u'sub-001_ses-sestest_dwi.bvec',
                     'Path': u'sub-001/ses-sestest/dwi', 'Folder': 'dwi',
-                     'Modality': 'dwi', 'Acq': '', 'Run': ''
+                     'Modality': 'dwi', 'Acq': '', 'Run': '',
+                    'ignore': False
                     }
                 },
             u'measurements': [u'diffusion'], u'type': u'bvec'}
@@ -557,7 +566,8 @@ class BidsifyTestCases(unittest.TestCase):
                     'IntendedFor': [
                         {'Folder': 'anat'},
                         {'Folder': 'func'}
-                    ]
+                    ],
+                    'ignore': False
                     }
                 },
             u'measurements': [u'field_map'], u'type': u'nifti'}
@@ -594,7 +604,8 @@ class BidsifyTestCases(unittest.TestCase):
                     'IntendedFor': [
                         {'Folder': 'anat'},
                         {'Folder': 'func'}
-                    ]
+                    ],
+                    'ignore': False
                     },
                     'PhaseEncodingDirection': 'j'
                 },
@@ -623,7 +634,8 @@ class BidsifyTestCases(unittest.TestCase):
                 'template': 'dicom_file',
                 'Filename': '',
                 'Folder': 'sourcedata',
-                'Path': u'sourcedata/sub-001/ses-sestest'
+                'Path': u'sourcedata/sub-001/ses-sestest',
+                'ignore': False
                 }},
             u'measurements': [u'diffusion'],
             u'type': u'dicom'}
@@ -679,7 +691,8 @@ class BidsifyTestCases(unittest.TestCase):
                 'template': 'dicom_file',
                 'Filename': u'09 cmrr_mbepi_task-spatialfrequency_s6_2mm_66sl_PA_TR1.0.dcm.zip',
                 'Folder': 'sourcedata',
-                'Path': u'sourcedata/sub-001/ses-sestest'
+                'Path': u'sourcedata/sub-001/ses-sestest',
+                'ignore': False
                 }},
             u'name': u'09 cmrr_mbepi_task-spatialfrequency_s6_2mm_66sl_PA_TR1.0.dcm.zip',
             u'measurements': [u'diffusion'],
@@ -706,7 +719,7 @@ class BidsifyTestCases(unittest.TestCase):
             'info': {
                 'BIDS': {
                     'template': 'acquisition',
-                    'Ignore': False
+                    'ignore': False
                     }
                 },
                 'label': 'Acquisition_Label_Test'
@@ -738,7 +751,8 @@ class BidsifyTestCases(unittest.TestCase):
             'info': {
                 'BIDS': {
                     'template': 'acquisition_file',
-                    'Filename': '', 'Folder': 'acq-blue', 'Path': 'sub-12345/ses-haha/acq-blue'
+                    'Filename': '', 'Folder': 'acq-blue', 'Path': 'sub-12345/ses-haha/acq-blue',
+                    'ignore': False
                     }
                 },
             u'type': u'image',
@@ -767,7 +781,7 @@ class BidsifyTestCases(unittest.TestCase):
                 'BIDS': {
                     'Label': 'Session_Label_Test',
                     'template': 'session',
-                    'Ignore': False
+                    'ignore': False
                     }
                 },
                 'label': 'Session_Label_Test'
@@ -794,7 +808,8 @@ class BidsifyTestCases(unittest.TestCase):
             'info': {
                 'BIDS': {
                     'template': 'session_file',
-                    'Filename': '', 'Folder': 'ses-sestest', 'Path': 'sub-12345/ses-sestest'
+                    'Filename': '', 'Folder': 'ses-sestest', 'Path': 'sub-12345/ses-sestest',
+                    'ignore': False
                     }
                 },
             u'type': u'tabular'}
@@ -856,7 +871,8 @@ class BidsifyTestCases(unittest.TestCase):
             'info': {
                 'BIDS': {
                     'template': 'project_file',
-                    'Filename': '', 'Folder': '', 'Path': ''
+                    'Filename': '', 'Folder': '', 'Path': '',
+                    'ignore': False
                     }
                 },
             u'measurements': [u'unknown'], u'type': u'archive'}
@@ -888,7 +904,8 @@ class BidsifyTestCases(unittest.TestCase):
                     'Filename': u'sub-001_ses-sestest_T1w.nii.gz',
                     'Path': u'sub-001/ses-sestest/anat', 'Folder': 'anat',
                     'Run': '', 'Acq': '', 'Ce': '', 'Rec': '',
-                    'Modality': 'T1w', 'Mod': ''
+                    'Modality': 'T1w', 'Mod': '',
+                    'ignore': False
                     }
                 },
             u'measurements': [u'anatomy_t1w', u'anatomy_t2w'], u'type': u'nifti'}

--- a/tests/test_bidsify_flywheel.py
+++ b/tests/test_bidsify_flywheel.py
@@ -686,6 +686,33 @@ class BidsifyTestCases(unittest.TestCase):
             u'type': u'dicom'}
         self.assertEqual(container, container_expected)
 
+    def test_process_matching_template_acquisition(self):
+        """ """
+        # Define context
+        context = {
+            'container_type': 'acquisition',
+            'parent_container_type': 'session',
+            'project': {'label': 'Project_Label_Test'},
+            'subject': None,
+            'session': {'label': 'Session_Label_Test'},
+            'acquisition': {'label': 'Acquisition_Label_Test'},
+            'file': {},
+            'ext': '.zip'
+        }
+        # Call function
+        container = bidsify_flywheel.process_matching_templates(context)
+        # Define expected container
+        container_expected = {
+            'info': {
+                'BIDS': {
+                    'template': 'acquisition',
+                    'Ignore': False
+                    }
+                },
+                'label': 'Acquisition_Label_Test'
+            }
+        self.assertEqual(container, container_expected)
+
     def test_process_matching_templates_acquisition_file(self):
         """ """
         # Define context
@@ -739,7 +766,8 @@ class BidsifyTestCases(unittest.TestCase):
             'info': {
                 'BIDS': {
                     'Label': 'Session_Label_Test',
-                    'template': 'session'
+                    'template': 'session',
+                    'Ignore': False
                     }
                 },
                 'label': 'Session_Label_Test'

--- a/tests/test_export_bids.py
+++ b/tests/test_export_bids.py
@@ -185,7 +185,7 @@ class BidsExportTestCases(unittest.TestCase):
             'info': {
                 'BIDS': {
                     'template': 'acquisition',
-                    'Ignore': False
+                    'ignore': False
                 }
             },
             'label': 'Acquisition_Label_Test'
@@ -195,7 +195,7 @@ class BidsExportTestCases(unittest.TestCase):
             'info': {
                 'BIDS': {
                     'template': 'acquisition',
-                    'Ignore': True
+                    'ignore': True
                 }
             },
             'label': 'Acquisition_Label_Test'

--- a/tests/test_export_bids.py
+++ b/tests/test_export_bids.py
@@ -180,6 +180,28 @@ class BidsExportTestCases(unittest.TestCase):
         self.assertEqual(json_contents['TaskName'],
                 'testtaskname')
 
+    def test_exclude_containers(self):
+        container = {
+            'info': {
+                'BIDS': {
+                    'template': 'acquisition',
+                    'Ignore': False
+                }
+            },
+            'label': 'Acquisition_Label_Test'
+        }
+        self.assertTrue(not export_bids.is_container_excluded(container, 'BIDS'))
+        container = {
+            'info': {
+                'BIDS': {
+                    'template': 'acquisition',
+                    'Ignore': True
+                }
+            },
+            'label': 'Acquisition_Label_Test'
+        }
+        self.assertTrue(export_bids.is_container_excluded(container, 'BIDS'))
+
 if __name__ == "__main__":
 
     unittest.main()

--- a/tests/test_export_bids.py
+++ b/tests/test_export_bids.py
@@ -202,6 +202,27 @@ class BidsExportTestCases(unittest.TestCase):
         }
         self.assertTrue(export_bids.is_container_excluded(container, 'BIDS'))
 
+    def test_exclude_ignored_files(self):
+        container = {
+            'info': {
+                'BIDS': {
+                    'template': 'func_file',
+                    'ignore': False
+                }
+            }
+        }
+        self.assertTrue(not export_bids.is_file_excluded(container, 'BIDS', True))
+        container = {
+            'info': {
+                'BIDS': {
+                    'template': 'func_file',
+                    'ignore': True
+                }
+            }
+        }
+        self.assertTrue(export_bids.is_file_excluded(container, 'BIDS', True))
+
+
 if __name__ == "__main__":
 
     unittest.main()


### PR DESCRIPTION
Fixes #79 
Acquisitions and Sessions have Ignore property which can either be true or false, if it is true, the container and its children will not be exported.