### PR TITLE
Fixed bug for json files in acquisition folders on upload

### DIFF
--- a/upload_bids.py
+++ b/upload_bids.py
@@ -574,7 +574,7 @@ def upload_bids_dir(fw, bids_hierarchy, group_id, rootdir, hierarchy_type):
                         # Check if any acquisition files are of interest (to be parsed later)
                         #   interested in JSON files
                         if '.json' in fname:
-                            files_of_interest[val] = {
+                            files_of_interest[fname] = {
                                     '_id': context['acquisition']['_id'],
                                     'id_type': 'acquisition',
                                     'full_filename': full_fname


### PR DESCRIPTION
The filename for the sidecar files on upload in the acquisition folders were getting the error:
```
matches template=json_file
Traceback (most recent call last):
  File "code/upload_bids.py", line 898, in <module>
    rootdir, args.hierarchy_type
  File "code/upload_bids.py", line 580, in upload_bids_dir
    'full_filename': full_fname
UnboundLocalError: local variable 'val' referenced before assignment
```