### PR TITLE
Add option to only curate a single session

### DIFF
--- a/flywheel_bids/curate_bids.py
+++ b/flywheel_bids/curate_bids.py
@@ -121,14 +121,18 @@ def update_meta_info(fw, context):
     else:
         logger.info('Cannot determine container type: ' + context['container_type'])
 
-def curate_bids_dir(fw, project_id, reset=False, template_file=None):
+def curate_bids_dir(fw, project_id, session_id=None, reset=False, template_file=None, session_only=False):
     """
 
     fw: Flywheel client
     project_id: project id of project to curate
+    session_id: The optional session id to curate
+    reset: Whether or not to reset bids info before curation
+    template_file: The template file to use
+    session_only: If true, then only curate the provided session
 
     """
-    project = get_project_tree(fw, project_id)
+    project = get_project_tree(fw, project_id, session_id=session_id, session_only=session_only)
     curate_bids_tree(fw, project, reset, template_file, True)
 
 def curate_bids_tree(fw, project, reset=False, template_file=None, update=True):
@@ -211,7 +215,7 @@ def curate_bids_tree(fw, project, reset=False, template_file=None, update=True):
             if node.is_dirty():
                 update_meta_info(fw, context)
 
-def main_with_args(api_key, session_id, reset):
+def main_with_args(api_key, session_id, reset, session_only):
 
     ### Prep
     # Check API key - raises Error if key is invalid
@@ -222,9 +226,8 @@ def main_with_args(api_key, session_id, reset):
         print('Session id is required!')
         sys.exit(1)
 
-
     ### Curate BIDS project
-    curate_bids_dir(fw, project_id, reset=reset)
+    curate_bids_dir(fw, project_id, session_id, reset=reset, session_only=session_only)
 
 
 def main():
@@ -236,8 +239,10 @@ def main():
             required=False, default=None, help='Project Label on Flywheel instance')
     parser.add_argument('--session', dest='session_id', action='store',
             required=False, default=None, help='Session ID, used to look up project if project label is not readily available')
-    parser.add_argument('--reset', dest='reset', action='store_true', 
+    parser.add_argument('--reset', dest='reset', action='store_true',
             default=False, help='Reset BIDS data before running')
+    parser.add_argument('--session-only', dest='session_only', action='store_true',
+            default=False, help='Only curate the session identified by --session')
     parser.add_argument('--template-file', dest='template_file', action='store',
             default=None, help='Template file to use')
     args = parser.parse_args()
@@ -254,9 +259,8 @@ def main():
         print('Either project label or session id is required!')
         sys.exit(1)
 
-
     ### Curate BIDS project
-    curate_bids_dir(fw, project_id, reset=args.reset, template_file=args.template_file)
+    curate_bids_dir(fw, project_id, args.session_id, reset=args.reset, template_file=args.template_file, session_only=args.session_only)
 
 if __name__ == '__main__':
     main()

--- a/flywheel_bids/supporting_files/project_tree.py
+++ b/flywheel_bids/supporting_files/project_tree.py
@@ -122,17 +122,24 @@ def add_file_nodes(parent):
     for f in parent.get('files', []):
         parent.children.append(TreeNode('file', f))
 
-def get_project_tree(fw, project_id):
+def get_project_tree(fw, project_id, session_id=None, session_only=False):
     """
     Construct a project tree from the given project_id.
 
     Args:
         fw: Flywheel client
         project_id (str): project id of project to curate
+        session_id (str): Optional session_id if session_only
+        session_only (bool): Set to true to only get session identified by session_id
 
     Returns:
         TreeNode: The project (root) tree node
     """
+    if session_only and session_id:
+        logger.info('Running in single session mode! (session_id={})'.format(session_id))
+    else:
+        session_id = None
+
     # Get project
     logger.info('Getting project...')
     project_data = to_dict(fw, fw.get_project(project_id))
@@ -142,6 +149,9 @@ def get_project_tree(fw, project_id):
     # Get project sessions
     project_sessions = fw.get_project_sessions(project_id)
     for proj_ses in project_sessions:
+        if session_id and session_id != proj_ses['_id']:
+            continue
+
         session_data = to_dict(fw, fw.get_session(proj_ses['_id']))
         session_node = TreeNode('session', session_data)
         add_file_nodes(session_node)

--- a/flywheel_bids/supporting_files/project_tree.py
+++ b/flywheel_bids/supporting_files/project_tree.py
@@ -1,6 +1,7 @@
 import collections
 import logging
 import copy
+import sys
 
 if __name__ == '__main__':
     import utils
@@ -137,6 +138,9 @@ def get_project_tree(fw, project_id, session_id=None, session_only=False):
     """
     if session_only and session_id:
         logger.info('Running in single session mode! (session_id={})'.format(session_id))
+    elif session_only:
+        logger.error('Session only was specified, but no session id was given!')
+        sys.exit(1)
     else:
         session_id = None
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ from setuptools import setup, find_packages
 from setuptools.command.install import install
 
 NAME = "flywheel-bids"
-VERSION = "0.6.5"
+VERSION = "0.6.6"
 # To install the library, run the following
 #
 # python setup.py install


### PR DESCRIPTION
When resetting BIDS curation, often times you only want to operate on newer session(s). This is a small step in limiting the potential damage by performing a reset.

Refs #114 