### PR TITLE
Auto update custom

### DIFF
--- a/flywheel_bids/export_bids.py
+++ b/flywheel_bids/export_bids.py
@@ -410,19 +410,15 @@ def download_bids_dir(fw, container_id, container_type, outdir, src_data=False,
 
     download_bids_files(fw, filepath_downloads, dry_run)
 
-def export_bids(fw, bids_dir, project_label, subjects=None, sessions=None, folders=None, replace=False, 
-        dry_run=False, container_type=None, container_id=None, source_data=False, validate=True):
-
-    ### Prep
-    # Check directory name - ensure it exists
-    validate_dirname(bids_dir)
-
-    # Check that container args are valid
-    container_id = container_type = None
+def determine_container(project_label, container_type, container_id):
+    """
+    Figures out what container_type and container_id should be if not given
+    """
+    cid = ctype = None
     if container_type and container_id:
         # Download single container
-        container_id = container_id
-        container_type = container_type
+        cid = container_id
+        ctype = container_type
     else:
         if bool(container_id) != bool(container_type):
             logger.error('Did not provide all options necessary to download single container')
@@ -431,11 +427,22 @@ def export_bids(fw, bids_dir, project_label, subjects=None, sessions=None, folde
             logger.error('Project label information not provided')
             sys.exit(1)
         # Get project Id from label
-        container_id = utils.validate_project_label(fw, project_label)
-        container_type = 'project'
+        cid = utils.validate_project_label(fw, project_label)
+        ctype = 'project'
+    return ctype, cid
+
+def export_bids(fw, bids_dir, project_label, subjects=None, sessions=None, folders=None, replace=False,
+        dry_run=False, container_type=None, container_id=None, source_data=False, validate=True):
+
+    ### Prep
+    # Check directory name - ensure it exists
+    validate_dirname(bids_dir)
+
+    # Check that container args are valid
+    ctype, cid = determine_container(project_label, container_type, container_id)
 
     ### Download BIDS project
-    download_bids_dir(fw, container_id, container_type, bids_dir,
+    download_bids_dir(fw, cid, ctype, bids_dir,
             src_data=source_data, dry_run=dry_run, replace=replace,
             subjects=subjects, sessions=sessions, folders=folders)
 

--- a/flywheel_bids/supporting_files/bidsify_flywheel.py
+++ b/flywheel_bids/supporting_files/bidsify_flywheel.py
@@ -73,7 +73,10 @@ def update_properties(properties, context, obj):
             if "auto_update" in properties[key]:
                 auto_update = properties[key]["auto_update"]
                 if isinstance(auto_update, dict):
-                    value = utils.dict_lookup(context, auto_update['$value'])
+                    if auto_update.get('$process'):
+                        value = utils.process_string_template(auto_update['$value'], context)
+                    else:
+                        value = utils.dict_lookup(context, auto_update['$value'])
                     obj[key] = utils.format_value(auto_update['$format'], value)
                 else:
                     obj[key] = utils.process_string_template(auto_update, context)

--- a/flywheel_bids/supporting_files/bidsify_flywheel.py
+++ b/flywheel_bids/supporting_files/bidsify_flywheel.py
@@ -62,12 +62,21 @@ def add_properties(properties, obj, classification):
 # See process_string_template for details on how to use string templates
 # Updated keys are added to the obj object for later update to Flywheel
 
+# 'auto_update' can also be a dictionary with keys '$value' and '$format' that
+# will use util.format_value, the value is a direct dict_lookup, the string
+# is not processed
+
 def update_properties(properties, context, obj):
     for key in properties:
         proptype = properties[key]["type"]
         if proptype == "string":
             if "auto_update" in properties[key]:
-                obj[key] = utils.process_string_template(properties[key]['auto_update'],context)
+                auto_update = properties[key]["auto_update"]
+                if isinstance(auto_update, dict):
+                    value = utils.dict_lookup(context, auto_update['$value'])
+                    obj[key] = utils.format_value(auto_update['$format'], value)
+                else:
+                    obj[key] = utils.process_string_template(auto_update, context)
     return(obj)
 
 

--- a/flywheel_bids/supporting_files/templates.py
+++ b/flywheel_bids/supporting_files/templates.py
@@ -269,7 +269,7 @@ def apply_initializers(initializers, info, context):
                             resolvedValue = value
 
                         if '$format' in valueSpec and resolvedValue:
-                            resolvedValue = formatValue(valueSpec['$format'], resolvedValue)
+                            resolvedValue = utils.format_value(valueSpec['$format'], resolvedValue)
 
                         if resolvedValue:
                             break
@@ -398,26 +398,6 @@ def processValueMatch(value, match):
 def get_pattern(format_params):
     return format_params.get("$pattern")
 
-def formatValue(params, value):
-    """
-    Formats a string value based on given parameters i.e. {"$replace": {"$pattern": "ab", "$replacement": "c"}}
-    will return "dcf" from "dabf"
-    """
-    for param in params:
-        if "$replace" in param:
-            value = re.sub(get_pattern(param["$replace"]), param["$replace"].get('$replacement'), value)
-        elif "$lower" in param:
-            if isinstance(param['$lower'], dict) and get_pattern(param["$lower"]):
-                value = re.sub(get_pattern(param["$lower"]), lambda m: m.group(0).lower(), value)
-            else:
-                value = value.lower()
-        elif "$upper" in param:
-            if isinstance(param['$upper'], dict) and get_pattern(param["$upper"]):
-                value = re.sub(get_pattern(param["$upper"]), lambda m: m.group(0).upper(), value)
-            else:
-                value = value.upper()
-
-    return value
 
 def loadTemplates(templates_dir=None):
     """

--- a/flywheel_bids/supporting_files/templates.py
+++ b/flywheel_bids/supporting_files/templates.py
@@ -395,9 +395,6 @@ def processValueMatch(value, match):
 
         return value == match
 
-def get_pattern(format_params):
-    return format_params.get("$pattern")
-
 
 def loadTemplates(templates_dir=None):
     """

--- a/flywheel_bids/supporting_files/utils.py
+++ b/flywheel_bids/supporting_files/utils.py
@@ -168,7 +168,7 @@ def process_string_template(template, context):
                         # If not, take the entire result and remove underscores and dashes
                         else:
                             result = ''.join(x for x in result.replace('_', ' ').replace('-', ' ').title() if x.isalnum())
-                            result = result[0].lower() + result[1:]
+                            result = result[0] + result[1:]
 
                     # Replace the token with the result
                     template = template.replace(replace_token, str(result))
@@ -188,6 +188,28 @@ def process_string_template(template, context):
     processed_template = re.sub('\[|\]', '', template)
 
     return processed_template
+
+
+def format_value(params, value):
+    """
+    Formats a string value based on list of given parameters i.e. [{"$replace": {"$pattern": "ab", "$replacement": "c"}}]
+    will return "dcf" from "dabf"
+    """
+    for param in params:
+        if "$replace" in param:
+            value = re.sub(get_pattern(param["$replace"]), param["$replace"].get('$replacement'), value)
+        elif "$lower" in param:
+            if isinstance(param['$lower'], dict) and get_pattern(param["$lower"]):
+                value = re.sub(get_pattern(param["$lower"]), lambda m: m.group(0).lower(), value)
+            else:
+                value = value.lower()
+        elif "$upper" in param:
+            if isinstance(param['$upper'], dict) and get_pattern(param["$upper"]):
+                value = re.sub(get_pattern(param["$upper"]), lambda m: m.group(0).upper(), value)
+            else:
+                value = value.upper()
+
+    return value
 
 
 class RunCounter:

--- a/flywheel_bids/supporting_files/utils.py
+++ b/flywheel_bids/supporting_files/utils.py
@@ -210,6 +210,19 @@ def format_value(params, value):
                 value = re.sub(get_pattern(param["$upper"]), lambda m: m.group(0).upper(), value)
             else:
                 value = value.upper()
+        elif "$camelCase" in param:
+            if isinstance(param['$camelCase'], dict) and get_pattern(param["$camelCase"]):
+                patterns = get_pattern(param["$camelCase"])
+                if not isinstance(patterns, list):
+                    patterns = [pattern]
+                for pattern in patterns:
+                    value = value.replace(patter, ' ')
+                value = ''.join(x for x in value.title() if x.isalnum())
+                value = value[0].lower() + value[1:]
+            else:
+                # Best to not process string with <...> with $camelCase : true
+                value = ''.join(x for x in value.replace('_', ' ').replace('-', ' ').title() if x.isalnum())
+                value = value[0].lower() + value[1:]
 
     return value
 

--- a/flywheel_bids/supporting_files/utils.py
+++ b/flywheel_bids/supporting_files/utils.py
@@ -167,7 +167,7 @@ def process_string_template(template, context):
                             label, result = result.split('-')
                         # If not, take the entire result and remove underscores and dashes
                         else:
-                            result = ''.join(x for x in result.replace('_', ' ').replace('-', ' ').title() if x.isalnum())
+                            result = ''.join(x for x in result.replace('_', ' ').replace('-', ' ') if x.isalnum())
                             result = result[0] + result[1:]
 
                     # Replace the token with the result
@@ -188,6 +188,10 @@ def process_string_template(template, context):
     processed_template = re.sub('\[|\]', '', template)
 
     return processed_template
+
+
+def get_pattern(format_params):
+    return format_params.get("$pattern")
 
 
 def format_value(params, value):

--- a/flywheel_bids/supporting_files/utils.py
+++ b/flywheel_bids/supporting_files/utils.py
@@ -132,7 +132,7 @@ def normalize_strings(obj):
 # Use <path> for cases where you want the result converted to lowerCamelCase
 # Use {path} for cases where you want a literal value substitution
 # path uses dot notation to navigate the context for desired values
-# path examples:  <session.label>  returns session.label in lowercamelcase
+# path examples:  <session.label>  returns session.label withou _ and -
 #                 {file.info.BIDS.Filename} returns the value of file.info.BIDS.Filename
 #                 {file.info.BIDS.Modality} returns Modality without modification
 # example template string:
@@ -168,8 +168,6 @@ def process_string_template(template, context):
                         # If not, take the entire result and remove underscores and dashes
                         else:
                             result = ''.join(x for x in result.replace('_', ' ').replace('-', ' ') if x.isalnum())
-                            result = result[0] + result[1:]
-
                     # Replace the token with the result
                     template = template.replace(replace_token, str(result))
                 # If result not found, but the token is option, remove the token from the template

--- a/flywheel_bids/templates/bids-v1.json
+++ b/flywheel_bids/templates/bids-v1.json
@@ -86,7 +86,8 @@
 		"session": {
 			"description": "BIDS session template",
 			"properties": {
-				"Label": {"type": "string", "title": "Label", "default": "", "auto_update": "{session.label}"}
+				"Label": {"type": "string", "title": "Label", "default": "", "auto_update": "{session.label}"},
+				"Subject": {"type": "string", "title": "Subject Code", "default": "", "auto_update": "<subject.code>"}
 			},
 			"required": []
 		},
@@ -95,9 +96,9 @@
 			"properties": {
 				"Filename": {"$ref":"#/definitions/Filename"},
 				"Folder": {"type": "string", "title": "Folder", "default": "",
-					"auto_update": "[ses-<session.info.BIDS.Label>]"},
+					"auto_update": "[ses-{session.info.BIDS.Label}]"},
 				"Path": {"type": "string", "title": "Path", "default": "",
-					"auto_update": "sub-<subject.code>[/ses-<session.info.BIDS.Label>]"}
+					"auto_update": "sub-{session.info.BIDS.Subject}[/ses-{session.info.BIDS.Label}]"}
 			},
 			"required": ["Filename"]
 		},
@@ -114,7 +115,7 @@
 				"Folder": {"type": "string", "title": "Folder", "default": "",
 					"auto_update": "acq-<acquisition.label>"},
 				"Path": {"type": "string", "title": "Path", "default": "",
-					"auto_update": "sub-<subject.code>[/ses-<session.info.BIDS.Label>]/acq-<acquisition.label>"}
+					"auto_update": "sub-{session.info.BIDS.Subject}[/ses-{session.info.BIDS.Label}]/acq-<acquisition.label>"}
 			},
 			"required": ["Filename"]
 		},
@@ -122,10 +123,10 @@
 			"description": "BIDS template for anat files",
 			"properties": {
 				"Filename": {"type": "string", "title": "Filename", "default": "", "minLength": 1,
-					"auto_update": "sub-<subject.code>[_ses-<session.info.BIDS.Label>][_acq-{file.info.BIDS.Acq}][_ce-{file.info.BIDS.Ce}][_rec-{file.info.BIDS.Rec}][_run-{file.info.BIDS.Run}][_mod-{file.info.BIDS.Mod}]_{file.info.BIDS.Modality}{ext}"},
+					"auto_update": "sub-{session.info.BIDS.Subject}[_ses-{session.info.BIDS.Label}][_acq-{file.info.BIDS.Acq}][_ce-{file.info.BIDS.Ce}][_rec-{file.info.BIDS.Rec}][_run-{file.info.BIDS.Run}][_mod-{file.info.BIDS.Mod}]_{file.info.BIDS.Modality}{ext}"},
 				"Folder": {"type": "string", "title": "Folder", "default": "anat"},
 				"Path": {"type": "string", "title": "Path", "default": "",
-					"auto_update": "sub-<subject.code>[/ses-<session.info.BIDS.Label>]/{file.info.BIDS.Folder}"},
+					"auto_update": "sub-{session.info.BIDS.Subject}[/ses-{session.info.BIDS.Label}]/{file.info.BIDS.Folder}"},
 				"Acq": {"$ref":"#/definitions/Acq"},
 				"Ce": {"$ref":"#/definitions/Ce"},
 				"Rec": {"$ref":"#/definitions/Rec"},
@@ -157,10 +158,10 @@
 			"description": "BIDS template for func files",
 			"properties": {
 				"Filename": {"type": "string", "title": "Filename", "default": "", "minLength": 1,
-					"auto_update": "sub-<subject.code>[_ses-<session.info.BIDS.Label>]_task-{file.info.BIDS.Task}[_acq-{file.info.BIDS.Acq}][_rec-{file.info.BIDS.Rec}][_run-{file.info.BIDS.Run}][_echo-{file.info.BIDS.Echo}]_{file.info.BIDS.Modality}{ext}"},
+					"auto_update": "sub-{session.info.BIDS.Subject}[_ses-{session.info.BIDS.Label}]_task-{file.info.BIDS.Task}[_acq-{file.info.BIDS.Acq}][_rec-{file.info.BIDS.Rec}][_run-{file.info.BIDS.Run}][_echo-{file.info.BIDS.Echo}]_{file.info.BIDS.Modality}{ext}"},
 				"Folder": {"type": "string", "title": "Folder", "default": "func"},
 				"Path": {"type": "string", "title": "Path", "default": "",
-					"auto_update": "sub-<subject.code>[/ses-<session.info.BIDS.Label>]/{file.info.BIDS.Folder}"},
+					"auto_update": "sub-{session.info.BIDS.Subject}[/ses-{session.info.BIDS.Label}]/{file.info.BIDS.Folder}"},
 				"Acq": {"$ref":"#/definitions/Acq"},
 				"Task": {"$ref":"#/definitions/Task"},
 				"Rec": {"$ref":"#/definitions/Rec"},
@@ -181,10 +182,10 @@
 			"description": "BIDS template for task events files",
 			"properties": {
 				"Filename": {"type": "string", "title": "Filename", "default": "", "minLength": 1,
-					"auto_update": "sub-<subject.code>[_ses-<session.info.BIDS.Label>]_task-{file.info.BIDS.Task}[_acq-{file.info.BIDS.Acq}][_rec-{file.info.BIDS.Rec}][_run-{file.info.BIDS.Run}][_echo-{file.info.BIDS.Echo}]_events.tsv"},
+					"auto_update": "sub-{session.info.BIDS.Subject}[_ses-{session.info.BIDS.Label}]_task-{file.info.BIDS.Task}[_acq-{file.info.BIDS.Acq}][_rec-{file.info.BIDS.Rec}][_run-{file.info.BIDS.Run}][_echo-{file.info.BIDS.Echo}]_events.tsv"},
 				"Folder": {"type": "string", "title": "Folder", "default": "func"},
 				"Path": {"type": "string", "title": "Path", "default": "",
-					"auto_update": "sub-<subject.code>[/ses-<session.info.BIDS.Label>]/{file.info.BIDS.Folder}"},
+					"auto_update": "sub-{session.info.BIDS.Subject}[/ses-{session.info.BIDS.Label}]/{file.info.BIDS.Folder}"},
 				"Task": { "$ref": "#/definitions/Task" },
 				"Acq": {"$ref":"#/definitions/Acq"},
 				"Rec": {"$ref":"#/definitions/Rec"},
@@ -197,10 +198,10 @@
 			"description": "BIDS template for behavioral events files",
 			"properties": {
 				"Filename": {"type": "string", "title": "Filename", "default": "", "minLength": 1,
-					"auto_update": "sub-<subject.code>[_ses-<session.info.BIDS.Label>]_task-{file.info.BIDS.Task}_events.tsv"},
+					"auto_update": "sub-{session.info.BIDS.Subject}[_ses-{session.info.BIDS.Label}]_task-{file.info.BIDS.Task}_events.tsv"},
 				"Folder": {"type": "string", "title": "Folder", "default": "beh"},
 				"Path": {"type": "string", "title": "Path", "default": "",
-					"auto_update": "sub-<subject.code>[/ses-<session.info.BIDS.Label>]/{file.info.BIDS.Folder}"},
+					"auto_update": "sub-{session.info.BIDS.Subject}[/ses-{session.info.BIDS.Label}]/{file.info.BIDS.Folder}"},
 				"Task": {"$ref":"#/definitions/Task"}
 			},
 			"required": ["Filename", "Task"]
@@ -209,10 +210,10 @@
 			"description": "BIDS template for physio files",
 			"properties": {
 				"Filename": {"type": "string", "title": "Filename", "default": "", "minLength": 1,
-					"auto_update": "sub-<subject.code>[_ses-<session.info.BIDS.Label>]_task-{file.info.BIDS.Task}[_acq-{file.info.BIDS.Acq}][_rec-{file.info.BIDS.Rec}][_run-{file.info.BIDS.Run}][_echo-{file.info.BIDS.Echo}][_recording-{file.info.BIDS.recording}]_{file.info.BIDS.Modality}{ext}"},
+					"auto_update": "sub-{session.info.BIDS.Subject}[_ses-{session.info.BIDS.Label}]_task-{file.info.BIDS.Task}[_acq-{file.info.BIDS.Acq}][_rec-{file.info.BIDS.Rec}][_run-{file.info.BIDS.Run}][_echo-{file.info.BIDS.Echo}][_recording-{file.info.BIDS.recording}]_{file.info.BIDS.Modality}{ext}"},
 				"Folder": {"type": "string", "title": "Folder", "default": "func"},
 				"Path": {"type": "string", "title": "Path", "default": "",
-					"auto_update": "sub-<subject.code>[/ses-<session.info.BIDS.Label>]/{file.info.BIDS.Folder}"},
+					"auto_update": "sub-{session.info.BIDS.Subject}[/ses-{session.info.BIDS.Label}]/{file.info.BIDS.Folder}"},
 				"Acq": {"$ref":"#/definitions/Acq"},
 				"Task": {"$ref":"#/definitions/Task"},
 				"Rec": {"$ref":"#/definitions/Rec"},
@@ -232,10 +233,10 @@
 			"description": "BIDS template for diffusion files",
 			"properties": {
 				"Filename": {"type": "string", "title": "Filename", "default": "", "minLength": 1,
-					"auto_update":"sub-<subject.code>[_ses-<session.info.BIDS.Label>][_acq-{file.info.BIDS.Acq}][_run-{file.info.BIDS.Run}]_{file.info.BIDS.Modality}{ext}"},
+					"auto_update":"sub-{session.info.BIDS.Subject}[_ses-{session.info.BIDS.Label}][_acq-{file.info.BIDS.Acq}][_run-{file.info.BIDS.Run}]_{file.info.BIDS.Modality}{ext}"},
 				"Folder": {"type": "string", "title": "Folder", "default": "dwi"},
 				"Path": {"type": "string", "title": "Path", "default": "",
-					"auto_update": "sub-<subject.code>[/ses-<session.info.BIDS.Label>]/{file.info.BIDS.Folder}"},
+					"auto_update": "sub-{session.info.BIDS.Subject}[/ses-{session.info.BIDS.Label}]/{file.info.BIDS.Folder}"},
 				"Acq": {"$ref":"#/definitions/Acq"},
 				"Run": {"$ref":"#/definitions/Run"},
 				"Modality": {"type": "string", "title": "Modality Label", "default": "dwi",
@@ -251,10 +252,10 @@
 			"description": "BIDS template for field map files",
 			"properties": {
 				"Filename": {"type": "string", "title": "Filename", "default": "", "minLength": 1,
-					"auto_update":"sub-<subject.code>[_ses-<session.info.BIDS.Label>][_acq-{file.info.BIDS.Acq}][_run-{file.info.BIDS.Run}][_dir-{file.info.BIDS.Dir}]_{file.info.BIDS.Modality}{ext}"},
+					"auto_update":"sub-{session.info.BIDS.Subject}[_ses-{session.info.BIDS.Label}][_acq-{file.info.BIDS.Acq}][_run-{file.info.BIDS.Run}][_dir-{file.info.BIDS.Dir}]_{file.info.BIDS.Modality}{ext}"},
 				"Folder": {"type": "string", "title": "Folder", "default": "fmap"},
 				"Path": {"type": "string", "title": "Path", "default": "",
-					"auto_update": "sub-<subject.code>[/ses-<session.info.BIDS.Label>]/{file.info.BIDS.Folder}"},
+					"auto_update": "sub-{session.info.BIDS.Subject}[/ses-{session.info.BIDS.Label}]/{file.info.BIDS.Folder}"},
 				"Acq": {"$ref":"#/definitions/Acq"},
 				"Run": {"$ref":"#/definitions/Run"},
 				"Dir": {"type": "string", "title": "Dir Label", "default": ""},
@@ -278,10 +279,10 @@
 			"description": "BIDS template for phase encoded field map files",
 			"properties": {
 				"Filename": {"type": "string", "label": "Filename", "default": "",
-					"auto_update":"sub-<subject.code>[_ses-<session.info.BIDS.Label>][_acq-{file.info.BIDS.Acq}][_run-{file.info.BIDS.Run}]_dir-{file.info.BIDS.Dir}_{file.info.BIDS.Modality}{ext}"},
+					"auto_update":"sub-{session.info.BIDS.Subject}[_ses-{session.info.BIDS.Label}][_acq-{file.info.BIDS.Acq}][_run-{file.info.BIDS.Run}]_dir-{file.info.BIDS.Dir}_{file.info.BIDS.Modality}{ext}"},
 				"Folder": {"type": "string", "label": "Folder", "default": "fmap"},
 				"Path": {"type": "string", "label": "Path", "default": "",
-					"auto_update": "sub-<subject.code>[/ses-<session.info.BIDS.Label>]/{file.info.BIDS.Folder}"},
+					"auto_update": "sub-{session.info.BIDS.Subject}[/ses-{session.info.BIDS.Label}]/{file.info.BIDS.Folder}"},
 				"Acq": {"type": "string", "label": "Acq Label", "default": ""},
 				"Run": {"type": "string", "label": "Run Index", "default": ""},
 				"Dir": {"type": "string", "label": "Dir Label", "default": ""},
@@ -307,7 +308,7 @@
 				"Filename": {"$ref":"#/definitions/Filename"},
 				"Folder": {"type": "string", "title": "Folder", "default": "sourcedata"},
 				"Path": {"type": "string", "title": "Path", "default": "",
-					"auto_update": "{file.info.BIDS.Folder}/sub-<subject.code>[/ses-<session.info.BIDS.Label>]"}
+					"auto_update": "{file.info.BIDS.Folder}/sub-{session.info.BIDS.Subject}[/ses-{session.info.BIDS.Label}]"}
 			},
 			"required": ["Filename", "Folder"]
 		},
@@ -691,7 +692,7 @@
 			"filter": "file.info.BIDS.IntendedFor",
 			"resolveFor": "session",
 			"type": "file",
-			"format": "[ses-<session.info.BIDS.Label>/]{file.info.BIDS.Folder}/{file.info.BIDS.Filename}"
+			"format": "[ses-{session.info.BIDS.Label}/]{file.info.BIDS.Folder}/{file.info.BIDS.Filename}"
 		}
 	]
 }

--- a/flywheel_bids/templates/bids-v1.json
+++ b/flywheel_bids/templates/bids-v1.json
@@ -86,7 +86,7 @@
 		"session": {
 			"description": "BIDS session template",
 			"properties": {
-				"Label": {"type": "string", "title": "Label", "default": "", "auto_update": "{session.label}"},
+				"Label": {"type": "string", "title": "Label", "default": "", "auto_update": "<session.label>"},
 				"Subject": {"type": "string", "title": "Subject Code", "default": "", "auto_update": "<subject.code>"}
 			},
 			"required": []
@@ -113,9 +113,19 @@
 			"properties": {
 				"Filename": {"$ref": "#/definitions/Filename"},
 				"Folder": {"type": "string", "title": "Folder", "default": "",
-					"auto_update": "acq-<acquisition.label>"},
+					"auto_update": {
+						"$process": true,
+						"$value": "acq-<acquisition.label>",
+						"$format": [{"$lower": true}]
+					}
+				},
 				"Path": {"type": "string", "title": "Path", "default": "",
-					"auto_update": "sub-{session.info.BIDS.Subject}[/ses-{session.info.BIDS.Label}]/acq-<acquisition.label>"}
+					"auto_update": {
+						"$process": true,
+						"$value": "sub-{session.info.BIDS.Subject}[/ses-{session.info.BIDS.Label}]/acq-<acquisition.label>",
+						"$format": [{"$lower": true}]
+					}
+				}
 			},
 			"required": ["Filename"]
 		},

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ from setuptools import setup, find_packages
 from setuptools.command.install import install
 
 NAME = "flywheel-bids"
-VERSION = "0.6.6"
+VERSION = "0.6.7"
 # To install the library, run the following
 #
 # python setup.py install

--- a/tests/test_bidsify_flywheel.py
+++ b/tests/test_bidsify_flywheel.py
@@ -258,7 +258,7 @@ class BidsifyTestCases(unittest.TestCase):
             'parent_container_type': 'acquisition',
             'project': None,
             'subject': {u'code': u'001'},
-            'session': {u'label': u'sesTEST', 'info': {'BIDS': {'Label': u'sesTEST'}}},
+            'session': {u'label': u'sesTEST', 'info': {'BIDS': {'Label': u'sesTEST', 'Subject': u'001'}}},
             'acquisition': {u'label': u'acqTEST'},
             'file': {u'classification': {u'Measurement': u'T1', u'Intent': u'Structural'},
                     u'type': u'nifti'
@@ -272,8 +272,8 @@ class BidsifyTestCases(unittest.TestCase):
             'info': {
                 'BIDS': {
                     'template': 'anat_file',
-                    'Filename': u'sub-001_ses-sestest_T1w.nii.gz',
-                    'Path': u'sub-001/ses-sestest/anat', 'Folder': 'anat',
+                    'Filename': u'sub-001_ses-sesTEST_T1w.nii.gz',
+                    'Path': u'sub-001/ses-sesTEST/anat', 'Folder': 'anat',
                     'Run': '', 'Acq': '', 'Ce': '', 'Rec': '',
                     'Modality': 'T1w', 'Mod': '',
                     'ignore': False
@@ -290,7 +290,7 @@ class BidsifyTestCases(unittest.TestCase):
             'parent_container_type': 'acquisition',
             'project': None,
             'subject': {u'code': u'001'},
-            'session': {u'label': u'sesTEST', 'info': {'BIDS': {'Label': u'sesTEST'}}},
+            'session': {u'label': u'sesTEST', 'info': {'BIDS': {'Label': u'sesTEST', 'Subject': u'001'}}},
             'acquisition': {u'label': u'acqTEST'},
             'file': {u'classification': {u'Measurement': u'T2', u'Intent': u'Structural'},
                     u'type': u'nifti'
@@ -304,8 +304,8 @@ class BidsifyTestCases(unittest.TestCase):
             'info': {
                 'BIDS': {
                     'template': 'anat_file',
-                    'Filename': u'sub-001_ses-sestest_T2w.nii.gz',
-                    'Path': u'sub-001/ses-sestest/anat', 'Folder': 'anat',
+                    'Filename': u'sub-001_ses-sesTEST_T2w.nii.gz',
+                    'Path': u'sub-001/ses-sesTEST/anat', 'Folder': 'anat',
                     'Run': '', 'Acq': '', 'Ce': '', 'Rec': '',
                     'Modality': 'T2w', 'Mod': '',
                     'ignore': False
@@ -322,7 +322,7 @@ class BidsifyTestCases(unittest.TestCase):
             'parent_container_type': 'acquisition',
             'project': None,
             'subject': {u'code': u'001'},
-            'session': {u'label': u'sesTEST', 'info': {'BIDS': {'Label': u'sesTEST'}}},
+            'session': {u'label': u'sesTEST', 'info': {'BIDS': {'Label': u'sesTEST', 'Subject': u'001'}}},
             'run_counters': utils.RunCounterMap(),
             'acquisition': {u'label': u'acq_task-TEST_run+'},
             'file': {u'classification': {u'Intent': u'Functional'},
@@ -337,8 +337,8 @@ class BidsifyTestCases(unittest.TestCase):
             'info': {
                 'BIDS': {
                     'template': 'func_file',
-                    'Filename': u'sub-001_ses-sestest_task-TEST_run-1_bold.nii.gz',
-                    'Folder': 'func', 'Path': u'sub-001/ses-sestest/func',
+                    'Filename': u'sub-001_ses-sesTEST_task-TEST_run-1_bold.nii.gz',
+                    'Folder': 'func', 'Path': u'sub-001/ses-sesTEST/func',
                     'Acq': '', 'Task': 'TEST', 'Modality': 'bold',
                     'Rec': '', 'Run': '1', 'Echo': '',
                     'ignore': False
@@ -355,7 +355,7 @@ class BidsifyTestCases(unittest.TestCase):
             'parent_container_type': 'acquisition',
             'project': None,
             'subject': {u'code': u'001'},
-            'session': {u'label': u'sesTEST', 'info': {'BIDS': {'Label': u'sesTEST'}}},
+            'session': {u'label': u'sesTEST', 'info': {'BIDS': {'Label': u'sesTEST', 'Subject': u'001'}}},
             'acquisition': {u'label': u'acqTEST'},
             'file': {u'classification': {u'Intent': u'Functional'},
                     u'type': u'tabular data',
@@ -369,8 +369,8 @@ class BidsifyTestCases(unittest.TestCase):
             'info': {
                 'BIDS': {
                     'template': 'task_events_file',
-                    'Filename': u'sub-001_ses-sestest_task-{file.info.BIDS.Task}_events.tsv',
-                    'Folder': 'func', 'Path': u'sub-001/ses-sestest/func',
+                    'Filename': u'sub-001_ses-sesTEST_task-{file.info.BIDS.Task}_events.tsv',
+                    'Folder': 'func', 'Path': u'sub-001/ses-sesTEST/func',
                     'Acq': '', 'Task': '',
                     'Rec': '', 'Run': '', 'Echo': '',
                     'ignore': False
@@ -387,7 +387,7 @@ class BidsifyTestCases(unittest.TestCase):
             'parent_container_type': 'acquisition',
             'project': None,
             'subject': {u'code': u'001'},
-            'session': {u'label': u'sesTEST', 'info': {'BIDS': {'Label': u'sesTEST'}}},
+            'session': {u'label': u'sesTEST', 'info': {'BIDS': {'Label': u'sesTEST', 'Subject': u'001'}}},
             'acquisition': {u'label': u'acqTEST'},
             'file': {u'classification': {u'Custom': u'Behavioral'},
                     u'type': u'tabular data',
@@ -401,8 +401,8 @@ class BidsifyTestCases(unittest.TestCase):
             'info': {
                 'BIDS': {
                     'template': 'beh_events_file',
-                    'Filename': u'sub-001_ses-sestest_task-{file.info.BIDS.Task}_events.tsv',
-                    'Folder': 'beh', 'Path': u'sub-001/ses-sestest/beh', 'Task': '',
+                    'Filename': u'sub-001_ses-sesTEST_task-{file.info.BIDS.Task}_events.tsv',
+                    'Folder': 'beh', 'Path': u'sub-001/ses-sesTEST/beh', 'Task': '',
                     'ignore': False
                     }
                 },
@@ -417,7 +417,7 @@ class BidsifyTestCases(unittest.TestCase):
             'parent_container_type': 'acquisition',
             'project': None,
             'subject': {u'code': u'001'},
-            'session': {u'label': u'sesTEST', 'info': {'BIDS': {'Label': u'sesTEST'}}},
+            'session': {u'label': u'sesTEST', 'info': {'BIDS': {'Label': u'sesTEST', 'Subject': u'001'}}},
             'acquisition': {u'label': u'acqTEST'},
             'file': {u'classification': {u'Custom': u'Physio'},
                     u'type': u'tabular data',
@@ -431,8 +431,8 @@ class BidsifyTestCases(unittest.TestCase):
             'info': {
                 'BIDS': {
                     'template': 'physio_task_file',
-                    'Filename': u'sub-001_ses-sestest_task-{file.info.BIDS.Task}_physio.tsv',
-                    'Folder': 'func', 'Path': u'sub-001/ses-sestest/func',
+                    'Filename': u'sub-001_ses-sesTEST_task-{file.info.BIDS.Task}_physio.tsv',
+                    'Folder': 'func', 'Path': u'sub-001/ses-sesTEST/func',
                     'Acq': '', 'Task': '',
                     'Modality': 'physio',
                     'Rec': '',
@@ -453,7 +453,7 @@ class BidsifyTestCases(unittest.TestCase):
             'parent_container_type': 'acquisition',
             'project': None,
             'subject': {u'code': u'001'},
-            'session': {u'label': u'sesTEST', 'info': {'BIDS': {'Label': u'sesTEST'}}},
+            'session': {u'label': u'sesTEST', 'info': {'BIDS': {'Label': u'sesTEST', 'Subject': u'001'}}},
             'acquisition': {u'label': u'acqTEST'},
             'file': {u'classification': {u'Measurement': u'Diffusion', u'Intent': u'Structural'},
                     u'type': u'nifti'
@@ -467,8 +467,8 @@ class BidsifyTestCases(unittest.TestCase):
             'info': {
                 'BIDS': {
                     'template': 'diffusion_file',
-                    'Filename': u'sub-001_ses-sestest_dwi.nii.gz',
-                    'Path': u'sub-001/ses-sestest/dwi', 'Folder': 'dwi',
+                    'Filename': u'sub-001_ses-sesTEST_dwi.nii.gz',
+                    'Path': u'sub-001/ses-sesTEST/dwi', 'Folder': 'dwi',
                      'Modality': 'dwi', 'Acq': '', 'Run': '',
                     'ignore': False
                     }
@@ -484,7 +484,7 @@ class BidsifyTestCases(unittest.TestCase):
             'parent_container_type': 'acquisition',
             'project': None,
             'subject': {u'code': u'001'},
-            'session': {u'label': u'sesTEST', 'info': {'BIDS': {'Label': u'sesTEST'}}},
+            'session': {u'label': u'sesTEST', 'info': {'BIDS': {'Label': u'sesTEST', 'Subject': u'001'}}},
             'acquisition': {u'label': u'acqTEST'},
             'file': {u'classification': {u'Measurement': u'Diffusion', u'Intent': u'Structural'},
                     u'type': u'bval'
@@ -498,8 +498,8 @@ class BidsifyTestCases(unittest.TestCase):
             'info': {
                 'BIDS': {
                     'template': 'diffusion_file',
-                    'Filename': u'sub-001_ses-sestest_dwi.bval',
-                    'Path': u'sub-001/ses-sestest/dwi', 'Folder': 'dwi',
+                    'Filename': u'sub-001_ses-sesTEST_dwi.bval',
+                    'Path': u'sub-001/ses-sesTEST/dwi', 'Folder': 'dwi',
                      'Modality': 'dwi', 'Acq': '', 'Run': '',
                     'ignore': False
                     }
@@ -515,7 +515,7 @@ class BidsifyTestCases(unittest.TestCase):
             'parent_container_type': 'acquisition',
             'project': None,
             'subject': {u'code': u'001'},
-            'session': {u'label': u'sesTEST', 'info': {'BIDS': {'Label': u'sesTEST'}}},
+            'session': {u'label': u'sesTEST', 'info': {'BIDS': {'Label': u'sesTEST', 'Subject': u'001'}}},
             'acquisition': {u'label': u'acqTEST'},
             'file': {u'classification': {u'Measurement': u'Diffusion', u'Intent': u'Structural'},
                     u'type': u'bvec'
@@ -529,8 +529,8 @@ class BidsifyTestCases(unittest.TestCase):
             'info': {
                 'BIDS': {
                     'template': 'diffusion_file',
-                    'Filename': u'sub-001_ses-sestest_dwi.bvec',
-                    'Path': u'sub-001/ses-sestest/dwi', 'Folder': 'dwi',
+                    'Filename': u'sub-001_ses-sesTEST_dwi.bvec',
+                    'Path': u'sub-001/ses-sesTEST/dwi', 'Folder': 'dwi',
                      'Modality': 'dwi', 'Acq': '', 'Run': '',
                     'ignore': False
                     }
@@ -546,7 +546,7 @@ class BidsifyTestCases(unittest.TestCase):
             'parent_container_type': 'acquisition',
             'project': None,
             'subject': {u'code': u'001'},
-            'session': {u'label': u'sesTEST', 'info': {'BIDS': {'Label': u'sesTEST'}}},
+            'session': {u'label': u'sesTEST', 'info': {'BIDS': {'Label': u'sesTEST', 'Subject': u'001'}}},
             'acquisition': {u'label': u'acqTEST'},
             'file': {u'classification': {u'Intent': u'Fieldmap'},
                     u'type': u'nifti',
@@ -560,8 +560,8 @@ class BidsifyTestCases(unittest.TestCase):
             'info': {
                 'BIDS': {
                     'template': 'fieldmap_file',
-                    'Filename': u'sub-001_ses-sestest_fieldmap.nii.gz',
-                    'Folder': 'fmap', 'Path': u'sub-001/ses-sestest/fmap',
+                    'Filename': u'sub-001_ses-sesTEST_fieldmap.nii.gz',
+                    'Folder': 'fmap', 'Path': u'sub-001/ses-sesTEST/fmap',
                     'Acq': '', 'Run': '', 'Dir': '', 'Modality': 'fieldmap',
                     'IntendedFor': [
                         {'Folder': 'anat'},
@@ -581,7 +581,7 @@ class BidsifyTestCases(unittest.TestCase):
             'parent_container_type': 'acquisition',
             'project': None,
             'subject': {u'code': u'001'},
-            'session': {u'label': u'sesTEST', 'info': {'BIDS': {'Label': u'sesTEST'}}},
+            'session': {u'label': u'sesTEST', 'info': {'BIDS': {'Label': u'sesTEST', 'Subject': u'001'}}},
             'acquisition': {u'label': u'acqTEST Topup PA'}, # Acquisition label needs to contain
             'file': {u'classification': {u'Intent': u'Fieldmap'},
                     u'type': u'nifti'
@@ -595,8 +595,8 @@ class BidsifyTestCases(unittest.TestCase):
             'info': {
                 'BIDS': {
                     'template': 'fieldmap_phase_encoded_file',
-                    'Filename': u'sub-001_ses-sestest_dir-PA_epi.nii.gz',
-                    'Folder': 'fmap', 'Path': u'sub-001/ses-sestest/fmap',
+                    'Filename': u'sub-001_ses-sesTEST_dir-PA_epi.nii.gz',
+                    'Folder': 'fmap', 'Path': u'sub-001/ses-sesTEST/fmap',
                     'Acq': '', 'Run': '', 'Dir': 'PA', 'Modality': 'epi',
                     'IntendedFor': [
                         {'Folder': 'anat'},
@@ -615,7 +615,7 @@ class BidsifyTestCases(unittest.TestCase):
             'parent_container_type': 'acquisition',
             'project': {u'label': 'hello'},
             'subject': {u'code': u'001'},
-            'session': {u'label': u'sesTEST', 'info': {'BIDS': {'Label': u'sesTEST'}}},
+            'session': {u'label': u'sesTEST', 'info': {'BIDS': {'Label': u'sesTEST', 'Subject': u'001'}}},
             'acquisition': {u'label': u'acqTEST'},
             'file': {
                 u'classification': {u'Measurement': u'Diffusion', u'Intent': u'Structural'},
@@ -630,7 +630,7 @@ class BidsifyTestCases(unittest.TestCase):
                 'template': 'dicom_file',
                 'Filename': '',
                 'Folder': 'sourcedata',
-                'Path': u'sourcedata/sub-001/ses-sestest',
+                'Path': u'sourcedata/sub-001/ses-sesTEST',
                 'ignore': False
                 }},
             u'classification': {u'Measurement': u'Diffusion', u'Intent': u'Structural'},
@@ -644,7 +644,7 @@ class BidsifyTestCases(unittest.TestCase):
             'parent_container_type': 'acquisition',
             'project': {u'label': 'hello'},
             'subject': {u'code': u'001'},
-            'session': {u'label': u'sesTEST', 'info': {'BIDS': {'Label': u'sesTEST'}}},
+            'session': {u'label': u'sesTEST', 'info': {'BIDS': {'Label': u'sesTEST', 'Subject': u'001'}}},
             'acquisition': {u'label': u'acqTEST', u'id': u'09090'},
             'file': {
                 u'name': u'4784_1_1_localizer',
@@ -671,7 +671,7 @@ class BidsifyTestCases(unittest.TestCase):
             'parent_container_type': 'acquisition',
             'project': {u'label': 'hello'},
             'subject': {u'code': u'001'},
-            'session': {u'label': u'sesTEST', 'info': {'BIDS': {'Label': u'sesTEST'}}},
+            'session': {u'label': u'sesTEST', 'info': {'BIDS': {'Label': u'sesTEST', 'Subject': u'001'}}},
             'acquisition': {u'label': u'acqTEST'},
             'file': {
                 u'name': u'09 cmrr_mbepi_task-spatialfrequency_s6_2mm_66sl_PA_TR1.0.dcm.zip',
@@ -687,7 +687,7 @@ class BidsifyTestCases(unittest.TestCase):
                 'template': 'dicom_file',
                 'Filename': u'09 cmrr_mbepi_task-spatialfrequency_s6_2mm_66sl_PA_TR1.0.dcm.zip',
                 'Folder': 'sourcedata',
-                'Path': u'sourcedata/sub-001/ses-sestest',
+                'Path': u'sourcedata/sub-001/ses-sesTEST',
                 'ignore': False
                 }},
             u'name': u'09 cmrr_mbepi_task-spatialfrequency_s6_2mm_66sl_PA_TR1.0.dcm.zip',
@@ -730,7 +730,7 @@ class BidsifyTestCases(unittest.TestCase):
             'parent_container_type': 'acquisition',
             'project': {'label': 'testproject'},
             'subject': {'code': '12345'},
-            'session': {'label': 'haha', 'info': {'BIDS': {'Label': 'haha'}}},
+            'session': {'label': 'haha', 'info': {'BIDS': {'Label': 'haha', 'Subject': '12345'}}},
             'acquisition':{'label': 'blue', u'id': u'ID'},
             'file': {u'type': u'image', u'name': u'fname'},
             'ext': '.jpg'
@@ -756,14 +756,14 @@ class BidsifyTestCases(unittest.TestCase):
             }
         self.assertEqual(container, container_expected)
 
-    def test_process_mathcing_templates_session(self):
+    def test_process_matching_templates_session(self):
         """ """
         # Define context
         context = {
             'container_type': 'session',
             'parent_container_type': 'project',
             'project': {'label': 'Project_Label_Test'},
-            'subject': None,
+            'subject': {'code' : '12345'},
             'session': {'label': 'Session_Label_Test'},
             'acquisition': None,
             'file': {},
@@ -775,7 +775,8 @@ class BidsifyTestCases(unittest.TestCase):
         container_expected = {
             'info': {
                 'BIDS': {
-                    'Label': 'Session_Label_Test',
+                    'Label': 'SessionLabelTest',
+                    'Subject': '12345',
                     'template': 'session',
                     'ignore': False
                     }
@@ -792,7 +793,7 @@ class BidsifyTestCases(unittest.TestCase):
             'parent_container_type': 'session',
             'project': {'label': 'testproject'},
             'subject': {'code': '12345'},
-            'session': {'label': u'sesTEST', 'info': {'BIDS': {'Label': u'sesTEST'}}},
+            'session': {'label': u'sesTEST', 'info': {'BIDS': {'Label': u'sesTEST', 'Subject': u'12345'}}},
             'acquisition': None,
             'file': {u'type': u'tabular'},
             'ext': '.tsv'
@@ -804,7 +805,7 @@ class BidsifyTestCases(unittest.TestCase):
             'info': {
                 'BIDS': {
                     'template': 'session_file',
-                    'Filename': '', 'Folder': 'ses-sestest', 'Path': 'sub-12345/ses-sestest',
+                    'Filename': '', 'Folder': 'ses-sesTEST', 'Path': 'sub-12345/ses-sesTEST',
                     'ignore': False
                     }
                 },
@@ -882,7 +883,7 @@ class BidsifyTestCases(unittest.TestCase):
             'parent_container_type': 'acquisition',
             'project': None,
             'subject': {u'code': u'001'},
-            'session': {u'label': u'sesTEST', 'info': {'BIDS': {'Label': u'sesTEST'}}},
+            'session': {u'label': u'sesTEST', 'info': {'BIDS': {'Label': u'sesTEST', 'Subject': u'001'}}},
             'acquisition': {u'label': u'acqTEST'},
             'file': {
                 u'classification': {u'Measurement': [u'T1', u'T2'], u'Intent': u'Structural'},
@@ -897,8 +898,8 @@ class BidsifyTestCases(unittest.TestCase):
             'info': {
                 'BIDS': {
                     'template': 'anat_file',
-                    'Filename': u'sub-001_ses-sestest_T1w.nii.gz',
-                    'Path': u'sub-001/ses-sestest/anat', 'Folder': 'anat',
+                    'Filename': u'sub-001_ses-sesTEST_T1w.nii.gz',
+                    'Path': u'sub-001/ses-sesTEST/anat', 'Folder': 'anat',
                     'Run': '', 'Acq': '', 'Ce': '', 'Rec': '',
                     'Modality': 'T1w', 'Mod': '',
                     'ignore': False
@@ -916,7 +917,7 @@ class BidsifyTestCases(unittest.TestCase):
             'parent_container_type': 'acquisition',
             'project': None,
             'subject': {u'code': u'001'},
-            'session': {u'label': u'sesTEST', 'info': {'BIDS': {'Label': u'sesTEST'}}},
+            'session': {u'label': u'sesTEST', 'info': {'BIDS': {'Label': u'sesTEST', 'Subject': u'001'}}},
             'run_counters': utils.RunCounterMap(),
             'acquisition': {u'label': u'acq_task-TEST_run+'},
             'file': {u'classification': {u'Intent': u'Functional'},

--- a/tests/test_export_bids.py
+++ b/tests/test_export_bids.py
@@ -244,6 +244,11 @@ class BidsExportTestCases(unittest.TestCase):
 
         os.remove('filePath')
 
+    def test_determine_single_container(self):
+        ctype = 'session'
+        cid = '123456789009876543211224'
+        self.assertTrue(export_bids.determine_container(None, ctype, cid) == (ctype, cid))
+
 
 if __name__ == "__main__":
 


### PR DESCRIPTION
### So a few changes:
- auto_update can be a dictionary with a `$value`, `$process`, and `$format` key
  - `$value`: The value to auto_update (What auto update used to be)
  - `$process`: To use string processing when determining the value (Using the <> or {})
  - `$format`: Does what format does in the initializer

- <...> Now does not enforce camelCase, as that was not part of bids.
- Subject code is stored in the session BIDS object so that we can format it in templates
- new `$camelCase` formatting to preserve previous functionality

So this change may affect the letter case of certain subjects and sessions, however, it is very easy to make those changes in the template. I'm not sure if it's a good idea to make this change to the customers, but having the default enforce camelCase for the session and subject fields of the filenames when BIDS does not isn't a great choice either.