### PR TITLE
Import source data from sourcedata folder

### DIFF
--- a/flywheel_bids/export_bids.py
+++ b/flywheel_bids/export_bids.py
@@ -110,9 +110,7 @@ def define_path(outdir, f, namespace):
     elif metadata.get('Filename'):
         # Ensure that the folder exists...
         full_path = os.path.join(outdir,
-                metadata['Path'])
-        if not os.path.exists(full_path):
-            os.makedirs(full_path)
+                                 metadata['Path'])
         # Define path to download file to...
         full_filename = os.path.join(full_path, metadata['Filename'])
     else:
@@ -289,6 +287,9 @@ def download_bids_dir(fw, container_id, container_type, outdir, src_data=False,
             if is_file_excluded(f, path):
                 continue
 
+            if not os.path.exists(os.path.dirname(path)):
+                os.makedirs(os.path.dirname(path))
+
             warn_if_bids_invalid(f, namespace)
 
 
@@ -346,6 +347,9 @@ def download_bids_dir(fw, container_id, container_type, outdir, src_data=False,
                 if is_file_excluded(f, path):
                     continue
 
+                if not os.path.exists(os.path.dirname(path)):
+                    os.makedirs(os.path.dirname(path))
+
                 warn_if_bids_invalid(f, namespace)
 
 
@@ -390,6 +394,9 @@ def download_bids_dir(fw, container_id, container_type, outdir, src_data=False,
                 # Don't exclude any files that specify exclusion
                 if is_file_excluded(f, path):
                     continue
+
+                if not os.path.exists(os.path.dirname(path)):
+                    os.makedirs(os.path.dirname(path))
 
                 warn_if_bids_invalid(f, namespace)
 

--- a/flywheel_bids/supporting_files/bidsify_flywheel.py
+++ b/flywheel_bids/supporting_files/bidsify_flywheel.py
@@ -99,7 +99,7 @@ def process_matching_templates(context, template=templates.DEFAULT_TEMPLATE, upl
             or ('template' not in container['info'][namespace]))
 
     templateDef = None
-    if container.get('info', {}).get('BIDS') == 'NA':
+    if container.get('info', {}).get(namespace) == 'NA':
         return container
 
     # add objects based on template if they don't already exist

--- a/flywheel_bids/supporting_files/utils.py
+++ b/flywheel_bids/supporting_files/utils.py
@@ -6,6 +6,7 @@ import sys
 import subprocess
 import jsonschema
 import collections
+from builtins import input
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger('utils')
@@ -225,6 +226,24 @@ def format_value(params, value):
                 value = value[0].lower() + value[1:]
 
     return value
+
+
+def confirmation_prompt(message):
+    """Continue prompting at the terminal for a yes/no repsonse
+
+    Arguments:
+        message (str): The prompt message
+
+    Returns:
+        bool: True if the user responded yes, otherwise False
+    """
+    responses = { 'yes': True, 'y': True, 'no': False, 'n': False }
+    while True:
+        six.print_('{} (yes/no): '.format(message), end='')
+        choice = input().lower()
+        if choice in responses:
+            return responses[choice]
+        six.print_('Please respond with "yes" or "no".')
 
 
 class RunCounter:

--- a/flywheel_bids/upload_bids.py
+++ b/flywheel_bids/upload_bids.py
@@ -936,7 +936,7 @@ def parse_meta_files(fw, files_of_interest):
             logger.info('Do not recognize filetype')
 
 def upload_bids(fw, bids_dir, group_id, project_label=None, hierarchy_type='Flywheel', validate=True,
-                include_source_data=False, local_properties=False, assume_yes=False):
+                include_source_data=False, local_properties=True, assume_yes=False):
     ### Prep
     # Check directory name - ensure it exists
     validate_dirname(bids_dir)

--- a/flywheel_bids/upload_bids.py
+++ b/flywheel_bids/upload_bids.py
@@ -133,7 +133,7 @@ def disable_project_rules(fw, project_id):
     for rule in fw.get_project_rules(project_id):
         fw.modify_project_rule(project_id, rule.id, {"disabled": True})
 
-def check_enabled_project_rules(fw, project_id):
+def check_enabled_rules(fw, project_id):
     for rule in fw.get_project_rules(project_id):
         if not rule.get('disabled'):
             return True

--- a/flywheel_bids/upload_bids.py
+++ b/flywheel_bids/upload_bids.py
@@ -155,7 +155,7 @@ def handle_project(fw, group_id, project_label):
             # project exists
             project = ep
             found = True
-            if check_enabled_rules(fw, project['_id']):
+            if check_enabled_rules(fw, project.to_dict()['id']):
                 logger.warning('Project has enabled rules, these may overwrite BIDS data. Either disable rules or run bids curation gear after data is uploaded.')
             break
     # If project does not exist, create project
@@ -719,7 +719,7 @@ def attach_json(fw, file_info):
             proj_sess = [s.to_dict() for s in fw.get_project_sessions(file_info['id'])]
             for proj_ses in proj_sess:
                 # Get acquisitions within session
-                ses_acqs = fw.get_session_acquisitions(proj_ses['id'])
+                ses_acqs = [a.to_dict() for a in fw.get_session_acquisitions(proj_ses['id'])]
                 for ses_acq in ses_acqs:
                     # Iterate over every acquisition file
                     for f in ses_acq['files']:
@@ -839,7 +839,7 @@ def attach_tsv(fw, file_info):
     # Get all sessions within project_id
     if file_info['id_type'] == 'project':
         # Get sessions within project
-        sessions = fw.get_project_sessions(file_info['id'])
+        sessions = [s.to_dict() for s in fw.get_project_sessions(file_info['id'])]
         # Iterate over sessions
         for ses in sessions:
             # Iterate over all values within TSV -- see if it matches
@@ -872,7 +872,7 @@ def attach_tsv(fw, file_info):
     # Else id_type is 'session' and we get acquisitions
     else:
         # Get all acquisitions within session
-        acquisitions = fw.get_session_acquisitions(file_info['id'])
+        acquisitions = [a.to_dict() for a in fw.get_session_acquisitions(file_info['id'])]
         # Iterate over all acquisitions within session
         for acq in acquisitions:
             # Get files within acquisitions

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 jsonschema>=2.6.0
 flywheel-sdk>=2.4.0
+future

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ VERSION = "0.6.8"
 # prerequisite: setuptools
 # http://pypi.python.org/pypi/setuptools
 
-REQUIRES = ["jsonschema>=2.6.0", "flywheel-sdk>=2.4.0"]
+REQUIRES = ["jsonschema>=2.6.0", "flywheel-sdk>=2.4.0", "future>=0.16.0"]
 
 class VerifyVersionCommand(install):
     """Custom command to verify that the git tag matches our version"""

--- a/tests/test_export_bids.py
+++ b/tests/test_export_bids.py
@@ -242,6 +242,18 @@ class BidsExportTestCases(unittest.TestCase):
         container['modified'] = dateutil.parser.parse("2718-03-28T20:40:59.54Z") # 700 years in the future
         self.assertTrue(not is_file_excluded(container, 'filePath'))
 
+        # Test source data and derived data are excluded
+        is_file_excluded = export_bids.is_file_excluded_options('BIDS', False, True)
+
+        container['info']['BIDS']['Path'] = 'sourcedata/file'
+        self.assertTrue(is_file_excluded(container, 'filePath'))
+
+        # Test source data and derived data are not excluded
+        is_file_excluded = export_bids.is_file_excluded_options('BIDS', True, True)
+
+        container['info']['BIDS']['Path'] = 'sourcedata/file'
+        self.assertTrue(not is_file_excluded(container, 'filePath'))
+
         os.remove('filePath')
 
     def test_determine_single_container(self):

--- a/tests/test_upload_bids.py
+++ b/tests/test_upload_bids.py
@@ -1,3 +1,4 @@
+import copy
 import csv
 import json
 import os
@@ -414,7 +415,7 @@ class BidsUploadTestCases(unittest.TestCase):
                     }
                 }
         # Call function
-        meta_info = upload_bids.fill_in_properties(context, folder_name)
+        meta_info = upload_bids.fill_in_properties(context, folder_name, True)
         # Assert equal
         self.assertEqual(meta_info_expected, meta_info)
 
@@ -452,7 +453,7 @@ class BidsUploadTestCases(unittest.TestCase):
                     }
                 }
         # Call function
-        meta_info = upload_bids.fill_in_properties(context, folder_name)
+        meta_info = upload_bids.fill_in_properties(context, folder_name, True)
         # Assert equal
         self.assertEqual(meta_info_expected, meta_info)
 
@@ -484,7 +485,45 @@ class BidsUploadTestCases(unittest.TestCase):
                     }
                 }
         # Call function
-        meta_info = upload_bids.fill_in_properties(context, folder_name)
+        meta_info = upload_bids.fill_in_properties(context, folder_name, True)
+        # Assert equal
+        self.assertEqual(meta_info_expected, meta_info)
+
+    def test_fill_in_properties_dicoms_without_local_values(self):
+        """ """
+        # Define inputs
+        context = {
+                'ext': '.dcm.zip',
+                'file': {
+                    'name': 'sub-01_ses-01_acq-01_ce-label1_rec-label2_run-01_mod-label3_T1w.dcm.zip',
+                    'info': {
+                        'BIDS': {
+                            'Ce': '',
+                            'Rec': '',
+                            'Run': '03',
+                            'Mod': '',
+                            'Modality': '',
+                            'Folder': 'sourcedata',
+                            'Filename': ''
+                            }
+                        }
+                    }
+                }
+        folder_name = 'anat'
+        # Define expected outputs
+        meta_info_expected = {
+                'BIDS': {
+                    'Ce': 'label1',
+                    'Rec': 'label2',
+                    'Run': '03',
+                    'Mod': 'label3',
+                    'Modality': 'T1w',
+                    'Folder': 'sourcedata',
+                    'Filename': context['file']['name']
+                    }
+                }
+        # Call function
+        meta_info = upload_bids.fill_in_properties(context, folder_name, False)
         # Assert equal
         self.assertEqual(meta_info_expected, meta_info)
 
@@ -516,7 +555,7 @@ class BidsUploadTestCases(unittest.TestCase):
                     }
                 }
         # Call function
-        meta_info = upload_bids.fill_in_properties(context, folder_name)
+        meta_info = upload_bids.fill_in_properties(context, folder_name, True)
         # Assert equal
         self.assertEqual(meta_info_expected, meta_info)
 
@@ -550,7 +589,7 @@ class BidsUploadTestCases(unittest.TestCase):
                     }
                 }
         # Call function
-        meta_info = upload_bids.fill_in_properties(context, folder_name)
+        meta_info = upload_bids.fill_in_properties(context, folder_name, True)
         # Assert equal
         self.assertEqual(meta_info_expected, meta_info)
 


### PR DESCRIPTION
### Changes
- upload `--source-data` flag to upload files under the sourcedata folder in the bids directory
- change all sdk models to dictionaries and use `id` instead of `_id`
- option to prioritize template defaults over values based on the file system (path and folder)
- disable project rules if a project is created, warn that rules may overwrite BIDS info for existing projects