### PR TITLE
[FLYW-480] Ignore label

### DIFF
--- a/flywheel_bids/templates/bids-v1.json
+++ b/flywheel_bids/templates/bids-v1.json
@@ -368,6 +368,23 @@
 			"template": "acquisition",
 			"where": {
 				"container_type": "acquisition"
+			},
+			"initialize": {
+				"ignore": {
+					"$switch": {
+						"$on": "acquisition.label",
+						"$cases": [
+							{
+								"$regex": "(^|_)ignore-BIDS",
+								"$value": true
+							},
+							{
+								"$default": true,
+								"$value": false
+							}
+						]
+					}
+				}
 			}
 		},
 		{

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -79,6 +79,66 @@ class RuleTestCases(unittest.TestCase):
         rule.initializeProperties(info, context)
         self.assertEqual( info, { 'Property': 'no_match' } )
 
+    def test_rule_initialize_switch_regex(self):
+        rule = templates.Rule({
+            'template': 'test',
+            'where': { 'x': True },
+            'initialize': {
+                'Property': {
+                    '$switch': {
+                        '$on': 'value',
+                        '$cases': [
+                            { '$regex': '^[a-z]_[0-9]$', '$value': 'match1' },
+                            { '$regex': '^[0-9]_[A-Z]$', '$value': 'match2' },
+                            { '$default': True, '$value': 'no_match' }
+                        ]
+                    }
+                }
+            }
+        })
+
+        context = { 'value': 'f_5'}
+        info = { }
+        rule.initializeProperties(info, context)
+        self.assertEqual( info, { 'Property': 'match1' } )
+
+        context = { 'value': '8_U' }
+        info = { }
+        rule.initializeProperties(info, context)
+        self.assertEqual( info, { 'Property': 'match2' } )
+
+        context = { 'value': 'asdf' }
+        info = { }
+        rule.initializeProperties(info, context)
+        self.assertEqual( info, { 'Property': 'no_match' } )
+
+    def test_rule_initialize_switch_neq(self):
+        rule = templates.Rule({
+            'template': 'test',
+            'where': {'x': True},
+            'initialize': {
+                'Property': {
+                    '$switch': {
+                        '$on': 'value',
+                        '$cases': [
+                            { '$neq': 'foo', '$value': 'match1' },
+                            { '$default': True, '$value': 'no_match' }
+                        ]
+                    }
+                }
+            }
+        })
+
+        context = { 'value': 'bar'}
+        info = { }
+        rule.initializeProperties(info, context)
+        self.assertEqual( info, { 'Property': 'match1' } )
+
+        context = { 'value': 'foo' }
+        info = { }
+        rule.initializeProperties(info, context)
+        self.assertEqual( info, { 'Property': 'no_match' } )
+
     def test_rule_initialize_format(self):
         rule = templates.Rule({
             'template': 'test',


### PR DESCRIPTION
Allow Users to have ignore-BIDS in the acquisition label in order to ignore the acquisition from being curated into BIDS.